### PR TITLE
fix(security): линейная проверка HTML вместо квадратичной

### DIFF
--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -233,7 +233,11 @@ def validate_html_tags(text: str) -> tuple[bool, str]:
     if not text:
         return True, ''
 
-    tag_pattern = r'<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^>]*>'
+    # [^<>], а не [^>]: на тексте из множества «<a» без закрывающей скобки
+    # второй вариант перебирает хвост заново с каждого «<». Замер на 80 КБ —
+    # 0.84 с здесь и 10 с в проверке структуры ниже, а длина HTML правовых
+    # страниц из кабинета ничем не ограничена.
+    tag_pattern = r'<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^<>]*>'
     tags = re.findall(tag_pattern, text)
 
     for is_closing, tag_name in tags:
@@ -246,7 +250,7 @@ def validate_html_tags(text: str) -> tuple[bool, str]:
 
 
 def validate_html_structure(text: str) -> tuple[bool, str]:
-    tag_pattern = r'<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^>]*?/?>'
+    tag_pattern = r'<(/?)([a-zA-Z][a-zA-Z0-9-]*)[^<>]*?/?>'
 
     matches = re.finditer(tag_pattern, text)
     tag_stack = []

--- a/tests/utils/test_tag_stripping_is_linear.py
+++ b/tests/utils/test_tag_stripping_is_linear.py
@@ -74,3 +74,36 @@ def test_visible_length_uses_the_linear_pattern():
 
     assert _visible_length('<b>Тариф</b>') == 5
     assert _visible_length('1 < 2') == 5
+
+
+def test_html_validator_stays_fast_on_unclosed_tags():
+    """Проверка HTML правовых страниц: их длина из кабинета ничем не ограничена.
+
+    Шаблон `[^>]*` после имени тега перебирал хвост заново с каждого «<»:
+    на 80 КБ из «<a» разбор структуры занимал 10 секунд заблокированного CPU.
+    """
+    from app.utils.validators import validate_html_tags
+
+    payload = '<a' * 40_000
+
+    start = time.perf_counter()
+    validate_html_tags(payload)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5, f'проверка HTML заняла {elapsed:.3f}s — шаблон снова квадратичный'
+
+
+@pytest.mark.parametrize(
+    ('source', 'valid'),
+    [
+        ('<b>жирный</b>', True),
+        ('<a href="https://example.com">ссылка</a>', True),
+        ('<b>1 < 2</b>', True),
+        ('<nosuchtag>текст</nosuchtag>', False),
+    ],
+)
+def test_html_validator_verdicts_unchanged(source, valid):
+    """Ускорение не должно менять вердикты на обычной разметке."""
+    from app.utils.validators import validate_html_tags
+
+    assert validate_html_tags(source)[0] is valid


### PR DESCRIPTION
Тот же py/polynomial-redos, что и в предыдущей правке, но в проверке разметки правовых страниц: шаблон `[^>]*` после имени тега перебирает хвост заново с каждого «<». Замер на 80 КБ из «<a»: разбор структуры — 10.2 секунды заблокированного CPU, поиск тегов — 0.84 с. После правки — 0.002 с.

Длина здесь особенно важна: HTML правил, политики и оферты приходит из кабинета обычной textarea и ничем не ограничен, в отличие от текста, который набирают в боте.

Вердикты на обычной разметке не меняются, а «<b>1 < 2</b>» теперь проходит как текст — прежний шаблон видел в «< 2</b>» тег.