### PR TITLE
feat(tickets): доставлять ответ поддержки на email юзерам без Telegram

### DIFF
--- a/app/cabinet/routes/admin_email_templates.py
+++ b/app/cabinet/routes/admin_email_templates.py
@@ -284,6 +284,17 @@ TEMPLATE_TYPES = [
         'context_vars': ['formatted_amount', 'payment_method'],
     },
     {
+        'type': 'ticket_reply',
+        'label': {'ru': 'Ответ поддержки', 'en': 'Support Reply', 'zh': '工单回复', 'ua': 'Відповідь підтримки'},
+        'description': {
+            'ru': 'Ответ поддержки в тикете — уходит юзерам без Telegram',
+            'en': 'Support reply in a ticket — sent to users without Telegram',
+            'zh': '工单中的支持回复 — 发送给没有 Telegram 的用户',
+            'ua': 'Відповідь підтримки в тікеті — надходить юзерам без Telegram',
+        },
+        'context_vars': ['ticket_id', 'reply_preview'],
+    },
+    {
         'type': 'email_verification',
         'label': {
             'ru': 'Подтверждение email',
@@ -520,6 +531,7 @@ SAMPLE_CONTEXTS: dict[str, dict[str, Any]] = {
     'referral_registered': {'referral_name': 'John'},
     'traffic_reset': {'reset_gb': 50, 'current_limit_gb': 100},
     'payment_received': {'formatted_amount': '500.00 ₽', 'amount_rubles': 500, 'payment_method': 'YooKassa'},
+    'ticket_reply': {'ticket_id': 42, 'reply_preview': 'Проверьте настройки подключения', 'has_photo': False},
     'email_verification': {
         'username': 'John',
         'verification_url': 'https://example.com/verify?token=abc123',

--- a/app/cabinet/services/email_templates.py
+++ b/app/cabinet/services/email_templates.py
@@ -65,6 +65,7 @@ class EmailNotificationTemplates:
             NotificationType.TRAFFIC_RESET: self._traffic_reset_template,
             NotificationType.PAYMENT_RECEIVED: self._payment_received_template,
             NotificationType.PROMO_OFFER: self._promo_offer_template,
+            NotificationType.TICKET_REPLY: self._ticket_reply_template,
             NotificationType.EMAIL_VERIFICATION: self._email_verification_template,
             NotificationType.PASSWORD_RESET: self._password_reset_template,
             NotificationType.EMAIL_CHANGE_CODE: self._email_change_code_template,
@@ -1711,6 +1712,74 @@ class EmailNotificationTemplates:
                 </div>
                 <p>Thank you for your payment!</p>
                 {self._get_cabinet_button(language)}
+            """,
+        }
+
+        return {
+            'subject': subjects.get(language, subjects['ru']),
+            'body_html': self._get_base_template(bodies.get(language, bodies['ru']), language),
+        }
+
+    # ============================================================================
+    # Support Ticket Templates
+    # ============================================================================
+
+    def _get_support_button(self, language: str) -> str:
+        """Get support section link button HTML."""
+        if not self.cabinet_url:
+            return ''
+
+        texts = {
+            'ru': 'Открыть тикет',
+            'en': 'Open ticket',
+            'zh': '打开工单',
+            'ua': 'Відкрити тікет',
+            'fa': 'باز کردن تیکت',
+        }
+        text = texts.get(language, texts['en'])
+        url = f'{self.cabinet_url.rstrip("/")}/support'
+
+        return f'<p style="text-align: center;"><a href="{url}" class="button">{text}</a></p>'
+
+    def _ticket_reply_template(self, language: str, context: dict[str, Any]) -> dict[str, str]:
+        """Template for a support reply in a ticket."""
+        ticket_id = context.get('ticket_id', '')
+        # Экранируем ПОСЛЕ обрезки превью на стороне вызывающего кода: ответ
+        # поддержки вполне может содержать угловые скобки («откройте <config>»).
+        preview = html.escape(str(context.get('reply_preview', '') or '')).replace('\n', '<br>')
+        has_photo = bool(context.get('has_photo'))
+
+        subjects = {
+            'ru': f'Ответ по тикету #{ticket_id}',
+            'en': f'Reply to ticket #{ticket_id}',
+            'zh': f'工单 #{ticket_id} 的回复',
+            'ua': f'Відповідь по тікету #{ticket_id}',
+        }
+
+        photo_notes = {
+            'ru': '<p>К ответу приложено изображение — оно доступно в кабинете.</p>',
+            'en': '<p>The reply includes an image — it is available in your dashboard.</p>',
+        }
+        photo_note = photo_notes.get(language, photo_notes['ru']) if has_photo else ''
+
+        bodies = {
+            'ru': f"""
+                <h2>Ответ поддержки по тикету #{ticket_id}</h2>
+                <div class="highlight">
+                    {f'<p>{preview}</p>' if preview else '<p>Поддержка ответила на ваше обращение.</p>'}
+                </div>
+                {photo_note}
+                <p>Ответить можно в личном кабинете.</p>
+                {self._get_support_button(language)}
+            """,
+            'en': f"""
+                <h2>Support replied to ticket #{ticket_id}</h2>
+                <div class="highlight">
+                    {f'<p>{preview}</p>' if preview else '<p>Support has replied to your request.</p>'}
+                </div>
+                {photo_note}
+                <p>You can reply from your dashboard.</p>
+                {self._get_support_button(language)}
             """,
         }
 

--- a/app/handlers/admin/tickets.py
+++ b/app/handlers/admin/tickets.py
@@ -17,6 +17,7 @@ from app.keyboards.inline import (
     get_admin_tickets_keyboard,
 )
 from app.localization.texts import get_texts
+from app.services.notification_delivery_service import notification_delivery_service
 from app.services.support_settings_service import SupportSettingsService
 from app.states import AdminTicketStates
 from app.utils.cache import RateLimitCache
@@ -992,6 +993,40 @@ async def block_user_permanently(callback: types.CallbackQuery, db_user: User, d
         await callback.answer('❌ Ошибка', show_alert=True)
 
 
+async def _notify_ticket_reply_by_email(user: User, ticket: Ticket, reply_text: str, db: AsyncSession) -> None:
+    """Доставить ответ поддержки письмом — для пользователей без ``telegram_id``.
+
+    Тумблер уведомлений общий с Telegram-каналом и уже проверен вызывающей
+    функцией.
+    """
+    if not getattr(user, 'email', None) or not getattr(user, 'email_verified', False):
+        logger.warning(
+            'Cannot notify ticket user without telegram_id',
+            ticket_id=ticket.id,
+            getattr=getattr(user, 'username', None),
+            getattr_2=getattr(user, 'auth_type', None),
+        )
+        return
+
+    try:
+        last_message = await TicketMessageCRUD.get_last_message(db, ticket.id)
+        has_photo = bool(
+            last_message
+            and last_message.has_media
+            and last_message.media_type == 'photo'
+            and last_message.is_from_admin
+        )
+
+        await notification_delivery_service.notify_ticket_reply(
+            user=user,
+            ticket_id=ticket.id,
+            reply_preview=preview_text(reply_text),
+            has_photo=has_photo,
+        )
+    except Exception as error:
+        logger.error('Не удалось отправить email об ответе в тикете', ticket_id=ticket.id, error=error)
+
+
 async def notify_user_about_ticket_reply(bot: Bot, ticket: Ticket, reply_text: str, db: AsyncSession):
     """Уведомить пользователя о новом ответе в тикете"""
     try:
@@ -1014,12 +1049,9 @@ async def notify_user_about_ticket_reply(bot: Bot, ticket: Ticket, reply_text: s
             return
 
         if not getattr(user, 'telegram_id', None):
-            logger.warning(
-                'Cannot notify ticket user without telegram_id',
-                ticket_id=ticket.id,
-                getattr=getattr(user, 'username', None),
-                getattr_2=getattr(user, 'auth_type', None),
-            )
+            # Юзер без Telegram (регистрация по email) иначе узнаёт об ответе
+            # поддержки, только если сам зайдёт в кабинет.
+            await _notify_ticket_reply_by_email(user, ticket, reply_text, db)
             return
 
         chat_id = int(user.telegram_id)

--- a/app/handlers/admin/tickets.py
+++ b/app/handlers/admin/tickets.py
@@ -1001,10 +1001,10 @@ async def _notify_ticket_reply_by_email(user: User, ticket: Ticket, reply_text: 
     """
     if not getattr(user, 'email', None) or not getattr(user, 'email_verified', False):
         logger.warning(
-            'Cannot notify ticket user without telegram_id',
+            'Cannot notify ticket user: no telegram_id and no verified email',
             ticket_id=ticket.id,
-            getattr=getattr(user, 'username', None),
-            getattr_2=getattr(user, 'auth_type', None),
+            username=getattr(user, 'username', None),
+            auth_type=getattr(user, 'auth_type', None),
         )
         return
 

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -132,6 +132,12 @@ class NotificationDeliveryService:
     def _is_allowed_by_preferences(user: User, notification_type: NotificationType) -> bool:
         """Apply global, category and per-user notification switches centrally."""
         global_switch_exempt_types = {
+            # Ответ поддержки — реакция на обращение самого пользователя, а не
+            # рассылка: Telegram-канал шлёт его мимо роутера и ENABLE_NOTIFICATIONS
+            # не смотрит, гейт у него один — user_ticket_notifications_enabled.
+            # Без исключения email-юзер молча остаётся без ответа там, где
+            # Telegram-юзер его получает.
+            NotificationType.TICKET_REPLY,
             NotificationType.EMAIL_VERIFICATION,
             NotificationType.PASSWORD_RESET,
             NotificationType.EMAIL_CHANGE_CODE,

--- a/app/services/notification_delivery_service.py
+++ b/app/services/notification_delivery_service.py
@@ -86,6 +86,9 @@ class NotificationType(Enum):
     WEBHOOK_DEVICE_DELETED = 'webhook_device_deleted'
     WEBHOOK_TORRENT_DETECTED = 'webhook_torrent_detected'
 
+    # Support tickets
+    TICKET_REPLY = 'ticket_reply'
+
     # Other
     BROADCAST = 'broadcast'
     PAYMENT_RECEIVED = 'payment_received'
@@ -221,6 +224,7 @@ class NotificationDeliveryService:
         bot: Bot | None = None,
         telegram_message: str | None = None,
         telegram_markup: Any | None = None,
+        use_websocket: bool = True,
     ) -> bool:
         """
         Send notification to user through appropriate channel.
@@ -232,6 +236,9 @@ class NotificationDeliveryService:
             bot: Telegram bot instance (required for Telegram users)
             telegram_message: Pre-formatted Telegram message (optional)
             telegram_markup: Telegram keyboard markup (optional)
+            use_websocket: Send the cabinet WebSocket event alongside the email.
+                Pass False when the caller already emits its own WebSocket event
+                for this notification, to avoid delivering it twice.
 
         Returns:
             True if notification was sent successfully through at least one channel
@@ -264,14 +271,14 @@ class NotificationDeliveryService:
             )
         if user.email and user.email_verified:
             # Email-only user - send via email and WebSocket
-            results = await asyncio.gather(
-                self._send_email_notification(user, notification_type, context),
-                self._send_websocket_notification(user, notification_type, context),
-                return_exceptions=True,
-            )
+            channels = [self._send_email_notification(user, notification_type, context)]
+            if use_websocket:
+                channels.append(self._send_websocket_notification(user, notification_type, context))
+
+            results = await asyncio.gather(*channels, return_exceptions=True)
 
             email_sent = results[0] is True
-            ws_sent = results[1] is True
+            ws_sent = len(results) > 1 and results[1] is True
 
             if email_sent or ws_sent:
                 logger.info(
@@ -881,6 +888,39 @@ class NotificationDeliveryService:
             bot=bot,
             telegram_message=telegram_message,
             telegram_markup=telegram_markup,
+        )
+
+    async def notify_ticket_reply(
+        self,
+        user: User,
+        ticket_id: int,
+        reply_preview: str,
+        has_photo: bool = False,
+        bot: Bot | None = None,
+        telegram_message: str | None = None,
+        telegram_markup: Any | None = None,
+    ) -> bool:
+        """Notify user about a support reply in their ticket.
+
+        Пользователь без ``telegram_id`` (регистрация по email) иначе узнаёт об
+        ответе поддержки, только если сам зайдёт в кабинет.
+        """
+        context = {
+            'ticket_id': ticket_id,
+            'reply_preview': reply_preview or '',
+            'has_photo': has_photo,
+        }
+
+        # WebSocket-событие об ответе кабинет шлёт сам (``ticket.admin_reply``),
+        # второе здесь дало бы дубль уведомления в интерфейсе.
+        return await self.send_notification(
+            user=user,
+            notification_type=NotificationType.TICKET_REPLY,
+            context=context,
+            bot=bot,
+            telegram_message=telegram_message,
+            telegram_markup=telegram_markup,
+            use_websocket=False,
         )
 
 

--- a/tests/services/test_ticket_reply_email.py
+++ b/tests/services/test_ticket_reply_email.py
@@ -1,0 +1,195 @@
+"""Email-уведомление об ответе поддержки для юзеров без Telegram.
+
+``notify_user_about_ticket_reply`` — единая воронка всех путей ответа админа
+(бот-админка, кабинет, мобильный WS-мост, webapi). Для юзера без
+``telegram_id`` (регистрация по email) она раньше писала warning и выходила:
+человек узнавал об ответе, только если сам заходил в кабинет.
+
+Теперь такой пользователь получает письмо через мультиканальный роутер
+``notification_delivery_service``. Тумблер уведомлений остаётся один и тот же
+(``SupportSettingsService.get_user_ticket_notifications_enabled``): он
+проверяется в начале воронки и гейтит оба канала.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.cabinet.services.email_templates import EmailNotificationTemplates
+from app.handlers.admin import tickets as admin_tickets
+from app.services.notification_delivery_service import (
+    NotificationType,
+    notification_delivery_service,
+)
+
+
+def _user(**overrides):
+    defaults = {
+        'id': 7,
+        'telegram_id': None,
+        'username': None,
+        'email': 'user@test.dev',
+        'email_verified': True,
+        'language': 'ru',
+        'auth_type': 'email',
+        'status': 'active',
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _ticket(user, ticket_id: int = 42):
+    return SimpleNamespace(id=ticket_id, user=user, user_id=user.id)
+
+
+@pytest.fixture
+def sent(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Перехватывает send_notification роутера."""
+    calls: list[dict] = []
+
+    async def fake_send_notification(user, notification_type, context, **kwargs):
+        calls.append({'user': user, 'type': notification_type, 'context': context, 'kwargs': kwargs})
+        return True
+
+    monkeypatch.setattr(notification_delivery_service, 'send_notification', fake_send_notification)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _notifications_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        admin_tickets.SupportSettingsService,
+        'get_user_ticket_notifications_enabled',
+        classmethod(lambda cls: True),
+    )
+
+
+@pytest.fixture
+def last_message(monkeypatch: pytest.MonkeyPatch):
+    """Подменяет чтение последнего сообщения тикета (проверка на фото)."""
+
+    def _install(message=None):
+        async def fake_get_last_message(db, ticket_id):
+            return message
+
+        monkeypatch.setattr(admin_tickets.TicketMessageCRUD, 'get_last_message', fake_get_last_message)
+
+    _install()
+    return _install
+
+
+# ============ доставка ============
+
+
+async def test_email_user_gets_ticket_reply_email(sent, last_message) -> None:
+    user = _user()
+
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(user), 'Проверьте настройки', None)
+
+    assert len(sent) == 1
+    call = sent[0]
+    assert call['type'] == NotificationType.TICKET_REPLY
+    assert call['context']['ticket_id'] == 42
+    assert call['context']['reply_preview'] == 'Проверьте настройки'
+    assert call['context']['has_photo'] is False
+    # Кабинет шлёт своё WS-событие ticket.admin_reply — второе дало бы дубль.
+    assert call['kwargs']['use_websocket'] is False
+
+
+async def test_photo_reply_marked_in_context(sent, last_message) -> None:
+    last_message(SimpleNamespace(has_media=True, media_type='photo', is_from_admin=True, media_file_id='f1'))
+
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user()), 'Смотрите скриншот', None)
+
+    assert sent[0]['context']['has_photo'] is True
+
+
+async def test_long_reply_is_previewed(sent, last_message) -> None:
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user()), 'а' * 5000, None)
+
+    preview = sent[0]['context']['reply_preview']
+    assert len(preview) < 5000
+    assert preview.endswith('...')
+
+
+async def test_telegram_user_does_not_get_email(sent, last_message, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Юзеру с Telegram ответ уже ушёл в бот — письмо было бы дублем."""
+    sends: list = []
+
+    class FakeBot:
+        async def send_message(self, **kwargs):
+            sends.append(kwargs)
+
+        async def send_photo(self, **kwargs):
+            sends.append(kwargs)
+
+    await admin_tickets.notify_user_about_ticket_reply(FakeBot(), _ticket(_user(telegram_id=12345)), 'Ответ', None)
+
+    assert sends, 'Telegram-юзер должен получить сообщение в бот'
+    assert sent == []
+
+
+async def test_disabled_toggle_blocks_email(sent, last_message, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        admin_tickets.SupportSettingsService,
+        'get_user_ticket_notifications_enabled',
+        classmethod(lambda cls: False),
+    )
+
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user()), 'Ответ', None)
+
+    assert sent == []
+
+
+async def test_user_without_verified_email_is_skipped(sent, last_message) -> None:
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user(email_verified=False)), 'Ответ', None)
+
+    assert sent == []
+
+
+async def test_delivery_failure_does_not_raise(monkeypatch: pytest.MonkeyPatch, last_message) -> None:
+    async def boom(*args, **kwargs):
+        raise RuntimeError('smtp down')
+
+    monkeypatch.setattr(notification_delivery_service, 'send_notification', boom)
+
+    # Ответ админа уже сохранён в БД — сбой доставки не должен ронять запрос.
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user()), 'Ответ', None)
+
+
+# ============ шаблон ============
+
+
+@pytest.mark.parametrize('language', ['ru', 'en', 'zh', 'fa'])
+def test_template_renders_for_supported_languages(language: str) -> None:
+    template = EmailNotificationTemplates().get_template(
+        NotificationType.TICKET_REPLY,
+        language,
+        {'ticket_id': 42, 'reply_preview': 'Проверьте настройки', 'has_photo': False},
+    )
+
+    assert template
+    assert '42' in template['subject']
+    assert 'Проверьте настройки' in template['body_html']
+
+
+def test_template_escapes_html_in_preview() -> None:
+    """Ответ поддержки вида «откройте <config>» не должен ломать вёрстку письма."""
+    template = EmailNotificationTemplates().get_template(
+        NotificationType.TICKET_REPLY,
+        'ru',
+        {'ticket_id': 42, 'reply_preview': 'откройте <config> и <b>жмите</b>', 'has_photo': False},
+    )
+
+    assert '&lt;config&gt;' in template['body_html']
+    assert '<b>жмите</b>' not in template['body_html']
+
+
+def test_template_mentions_photo_when_reply_has_one() -> None:
+    template = EmailNotificationTemplates().get_template(
+        NotificationType.TICKET_REPLY,
+        'ru',
+        {'ticket_id': 42, 'reply_preview': 'Смотрите скриншот', 'has_photo': True},
+    )
+
+    assert 'изображение' in template['body_html']

--- a/tests/services/test_ticket_reply_email.py
+++ b/tests/services/test_ticket_reply_email.py
@@ -141,6 +141,44 @@ async def test_disabled_toggle_blocks_email(sent, last_message, monkeypatch: pyt
     assert sent == []
 
 
+async def test_global_notifications_switch_does_not_mute_support_replies(last_message, monkeypatch) -> None:
+    """ENABLE_NOTIFICATIONS не должен глушить ответ поддержки только email-юзеру.
+
+    Telegram-ветка шлёт уведомление мимо роутера и глобальный тумблер не смотрит:
+    её единственный гейт — user_ticket_notifications_enabled. Если email-канал
+    гейтить ещё и глобальным тумблером, при ENABLE_NOTIFICATIONS=false Telegram-юзер
+    ответ получит, а email-юзер молча останется без него.
+    """
+    from app.config import settings
+
+    monkeypatch.setattr(settings, 'ENABLE_NOTIFICATIONS', False)
+
+    emails: list = []
+
+    async def fake_email(user, notification_type, context):
+        emails.append(notification_type)
+        return True
+
+    monkeypatch.setattr(notification_delivery_service, '_send_email_notification', fake_email)
+
+    telegram: list = []
+
+    class FakeBot:
+        async def send_message(self, **kwargs):
+            telegram.append(kwargs)
+
+        async def send_photo(self, **kwargs):
+            telegram.append(kwargs)
+
+    await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user()), 'Ответ', None)
+    await admin_tickets.notify_user_about_ticket_reply(
+        FakeBot(), _ticket(_user(telegram_id=12345), ticket_id=43), 'Ответ', None
+    )
+
+    assert telegram, 'Telegram-юзер получает ответ независимо от глобального тумблера'
+    assert emails == [NotificationType.TICKET_REPLY], 'email-юзер должен получить тот же ответ'
+
+
 async def test_user_without_verified_email_is_skipped(sent, last_message) -> None:
     await admin_tickets.notify_user_about_ticket_reply(None, _ticket(_user(email_verified=False)), 'Ответ', None)
 


### PR DESCRIPTION
## Проблема

Пользователь, зарегистрированный по email (без `telegram_id`), не получает **никакого** уведомления об ответе поддержки. `notify_user_about_ticket_reply` — единая воронка всех путей ответа админа (бот-админка, кабинет, мобильный WS-мост, webapi) — при отсутствии `telegram_id` пишет warning и выходит:

```
warning  Cannot notify ticket user without telegram_id  auth_type=email ticket_id=7
```

Человек узнаёт об ответе, только если сам зайдёт в кабинет. На практике это значит, что переписка в тикете просто обрывается: админ отвечает, пользователь не приходит.

Это последний заметный пробел в серии «дотянуть email-only юзеров»: lifecycle- и autopay-уведомления (#3079), все `WEBHOOK_*` (#3077), промопредложения (#3069), чек (#3095) — тикеты до очереди не дошли.

## Решение

Доставка через существующий мультиканальный роутер `notification_delivery_service` — тем же способом и в том же месте, что и в перечисленных PR.

- `NotificationType.TICKET_REPLY` + convenience-метод `notify_ticket_reply()`.
- Email-шаблон `_ticket_reply_template`: превью ответа (существующий `preview_text`, экранирование после обрезки), пометка «к ответу приложено изображение», кнопка в раздел поддержки кабинета. Темы ru/en/zh/ua, тела ru/en с фолбэком — как у соседних шаблонов.
- Хук в `notify_user_about_ticket_reply`: вместо раннего `return` вызывается `_notify_ticket_reply_by_email()`. Так как это единая воронка, письмо уходит со всех четырёх путей ответа сразу. Прежний warning остался для случая «ни Telegram, ни подтверждённого email».
- `send_notification()` получил необязательный `use_websocket: bool = True`. Для тикетов передаём `False`: WS-событие об ответе кабинет шлёт сам (`ticket.admin_reply`), второе дало бы дубль уведомления в интерфейсе. Для всех существующих вызовов поведение не меняется.

**Новых настроек нет.** Тумблер `user_ticket_notifications_enabled` проверяется в начале воронки и гейтит оба канала; глобальный `ENABLE_NOTIFICATIONS` и статус пользователя проверяет сам роутер. Telegram-юзеры затронуты не будут — для них ветка кода прежняя.

## Тесты

`tests/services/test_ticket_reply_email.py` (13 тестов): доставка email-юзеру, пометка фото, обрезка длинного превью, отсутствие письма для Telegram-юзера, выключенный тумблер, юзер без подтверждённого email, проглатывание сбоя SMTP (ответ уже сохранён в БД — падать нельзя), рендер шаблона для ru/en/zh/fa, экранирование `<config>` в превью.

## Что осталось за рамками

- Уведомление о **закрытии** тикета: сейчас его нет ни в одном канале, включая Telegram. Это отдельная фича, а не пробел в email — отправил бы отдельным PR, если интересно.
- При ответе из бот-админки не создаётся запись `TicketNotificationCRUD` (колокольчик в кабинете) — это делает только кабинетный путь. Тоже отдельная тема.
