### PR TITLE
feat(errors): журнал системных ошибок со статусом доставки

### DIFF
--- a/app/cabinet/routes/__init__.py
+++ b/app/cabinet/routes/__init__.py
@@ -39,6 +39,7 @@ from .admin_sales_stats import router as admin_sales_stats_router
 from .admin_servers import router as admin_servers_router
 from .admin_settings import router as admin_settings_router
 from .admin_stats import router as admin_stats_router
+from .admin_system_errors import router as admin_system_errors_router
 from .admin_tariffs import router as admin_tariffs_router
 from .admin_tickets import router as admin_tickets_router
 from .admin_traffic import router as admin_traffic_router
@@ -163,6 +164,7 @@ router.include_router(admin_apps_router)
 router.include_router(admin_roles_router)
 router.include_router(admin_policies_router)
 router.include_router(admin_audit_log_router)
+router.include_router(admin_system_errors_router)
 # Categories/tags/media routers MUST be before the main news router
 # to avoid /admin/news/{article_id} catching /admin/news/categories etc.
 router.include_router(admin_news_categories_router)

--- a/app/cabinet/routes/admin_system_errors.py
+++ b/app/cabinet/routes/admin_system_errors.py
@@ -1,0 +1,260 @@
+"""Admin system errors routes — журнал ошибок приложения и их доставки.
+
+Второй, независимый от Telegram канал: кабинет живёт на том же хосте, что и
+бот, и доступен напрямую, минуя прокси-пул. Поэтому когда все пути до
+Telegram лежат, ошибки всё равно видно здесь.
+"""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from typing import Any
+
+import structlog
+from aiogram import Bot
+from aiogram.types import BufferedInputFile
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.bot_factory import create_bot
+from app.config import settings
+from app.database.crud.system_errors import (
+    get_error_event,
+    get_error_summary,
+    list_error_events,
+    mark_delivery_result,
+)
+from app.database.models import SystemErrorEvent, User
+
+from ..dependencies import get_cabinet_db, require_permission
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix='/admin/system-errors', tags=['Admin System Errors'])
+
+
+# ============ Schemas ============
+
+
+class SystemErrorListItem(BaseModel):
+    """Строка списка — без трейсбека, чтобы не раздувать ответ."""
+
+    id: int
+    created_at: datetime | None = None
+    level: str
+    logger_name: str | None = None
+    event: str
+    error_type: str | None = None
+    user_id: int | None = None
+    delivery_status: str
+    delivery_attempts: int
+    delivered_at: datetime | None = None
+    has_traceback: bool = False
+
+
+class SystemErrorDetail(SystemErrorListItem):
+    """Полная запись, включая трейсбек и контекст."""
+
+    traceback: str | None = None
+    context: dict[str, Any] | None = None
+    last_attempt_at: datetime | None = None
+    delivery_error: str | None = None
+    dedup_hash: str | None = None
+
+
+class SystemErrorListResponse(BaseModel):
+    items: list[SystemErrorListItem]
+    total: int
+    limit: int
+    offset: int
+
+
+class SystemErrorSummary(BaseModel):
+    undelivered_total: int
+    last_24h: int
+    last_7d: int
+    by_status_7d: dict[str, int]
+    top_errors_7d: list[dict[str, Any]]
+
+
+# ============ Helpers ============
+
+_cached_bot: Bot | None = None
+
+# Telegram режет caption у документа на 1024 символах — длинный трейсбек
+# уезжает в приложенный файл, как и в обычном отчёте об ошибке.
+CAPTION_LIMIT = 900
+
+
+def _get_bot() -> Bot:
+    global _cached_bot
+    if _cached_bot is None:
+        _cached_bot = create_bot()
+    return _cached_bot
+
+
+def _build_retry_message(event: SystemErrorEvent) -> str:
+    created = event.created_at.isoformat() if event.created_at else '—'
+    parts = [
+        '<b>Повторная отправка ошибки</b>',
+        '',
+        f'<b>Тип:</b> <code>{html.escape(event.error_type or "—")}</code>',
+        f'<b>Логгер:</b> <code>{html.escape(event.logger_name or "—")}</code>',
+        f'<b>Когда:</b> {html.escape(created)}',
+        '',
+        f'<code>{html.escape(event.event or "")[:CAPTION_LIMIT]}</code>',
+    ]
+    return '\n'.join(parts)
+
+
+async def _resend_to_admin_chat(event: SystemErrorEvent) -> None:
+    """Отправить сохранённую ошибку в админ-чат. Бросает при неудаче."""
+    chat_id = getattr(settings, 'ADMIN_NOTIFICATIONS_CHAT_ID', None)
+    if not chat_id:
+        raise RuntimeError('ADMIN_NOTIFICATIONS_CHAT_ID не настроен')
+
+    topic_id = getattr(settings, 'ADMIN_NOTIFICATIONS_ERRORS_TOPIC_ID', None) or getattr(
+        settings, 'ADMIN_NOTIFICATIONS_TOPIC_ID', None
+    )
+    kwargs: dict[str, Any] = {'chat_id': chat_id, 'parse_mode': 'HTML'}
+    if topic_id:
+        kwargs['message_thread_id'] = topic_id
+
+    bot = _get_bot()
+    text = _build_retry_message(event)
+
+    if event.traceback:
+        document = BufferedInputFile(
+            file=event.traceback.encode('utf-8'),
+            filename=f'error_{event.id}.txt',
+        )
+        await bot.send_document(document=document, caption=text, **kwargs)
+    else:
+        await bot.send_message(text=text, disable_web_page_preview=True, **kwargs)
+
+
+def _to_detail(event: SystemErrorEvent) -> SystemErrorDetail:
+    base = _to_list_item(event)
+    return SystemErrorDetail(
+        **base.model_dump(),
+        traceback=event.traceback,
+        context=event.context,
+        last_attempt_at=event.last_attempt_at,
+        delivery_error=event.delivery_error,
+        dedup_hash=event.dedup_hash,
+    )
+
+
+def _to_list_item(event) -> SystemErrorListItem:
+    return SystemErrorListItem(
+        id=event.id,
+        created_at=event.created_at,
+        level=event.level,
+        logger_name=event.logger_name,
+        event=event.event,
+        error_type=event.error_type,
+        user_id=event.user_id,
+        delivery_status=event.delivery_status,
+        delivery_attempts=event.delivery_attempts,
+        delivered_at=event.delivered_at,
+        has_traceback=bool(event.traceback),
+    )
+
+
+# ============ Routes ============
+
+
+@router.get('/summary', response_model=SystemErrorSummary)
+async def system_errors_summary(
+    admin: User = Depends(require_permission('system_errors:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Сводка для бейджа в шапке и верхнего блока страницы."""
+    summary = await get_error_summary(db)
+    return SystemErrorSummary(**summary)
+
+
+@router.get('', response_model=SystemErrorListResponse)
+async def list_system_errors(
+    admin: User = Depends(require_permission('system_errors:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+    level: str | None = Query(default=None),
+    delivery_status: str | None = Query(default=None),
+    logger_name: str | None = Query(default=None),
+    search: str | None = Query(default=None),
+    undelivered_only: bool = Query(default=False),
+    date_from: datetime | None = Query(default=None),
+    date_to: datetime | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """Список ошибок с фильтрами по уровню, статусу доставки и периоду."""
+    events, total = await list_error_events(
+        db,
+        level=level,
+        delivery_status=delivery_status,
+        logger_name=logger_name,
+        search=search,
+        undelivered_only=undelivered_only,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        offset=offset,
+    )
+
+    return SystemErrorListResponse(
+        items=[_to_list_item(event) for event in events],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get('/{event_id}', response_model=SystemErrorDetail)
+async def get_system_error(
+    event_id: int,
+    admin: User = Depends(require_permission('system_errors:read')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Полная запись с трейсбеком и контекстом."""
+    event = await get_error_event(db, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail='Error event not found')
+
+    return _to_detail(event)
+
+
+@router.post('/{event_id}/retry', response_model=SystemErrorDetail)
+async def retry_system_error_delivery(
+    event_id: int,
+    admin: User = Depends(require_permission('system_errors:manage')),
+    db: AsyncSession = Depends(get_cabinet_db),
+):
+    """Повторно отправить сохранённую ошибку в админ-чат.
+
+    В отличие от автоматического пути, здесь нет троттлинга и дедупликации —
+    админ жмёт кнопку осознанно.
+    """
+    event = await get_error_event(db, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail='Error event not found')
+
+    try:
+        await _resend_to_admin_chat(event)
+    except Exception as e:
+        # ВАЖНО: warning, не error. logger.error отсюда уйдёт в
+        # TelegramNotifierProcessor и породит новую запись об ошибке
+        # прямо во время разбора старой.
+        logger.warning(
+            'Повторная отправка ошибки в админ-чат не удалась',
+            event_id=event_id,
+            error=str(e)[:200],
+        )
+        await mark_delivery_result(db, event, delivered=False, error=str(e))
+        return _to_detail(event)
+
+    await mark_delivery_result(db, event, delivered=True)
+    return _to_detail(event)

--- a/app/database/crud/system_errors.py
+++ b/app/database/crud/system_errors.py
@@ -1,0 +1,149 @@
+"""Выборки по журналу системных ошибок (``system_error_events``)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import SystemErrorEvent
+
+
+# Статусы, означающие «админ об этом не узнал»
+UNDELIVERED_STATUSES = ('pending', 'failed')
+
+
+async def list_error_events(
+    db: AsyncSession,
+    *,
+    level: str | None = None,
+    delivery_status: str | None = None,
+    logger_name: str | None = None,
+    search: str | None = None,
+    undelivered_only: bool = False,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[SystemErrorEvent], int]:
+    """Постранично отдать события с фильтрами. Возвращает (записи, всего)."""
+    conditions = []
+
+    if level:
+        conditions.append(SystemErrorEvent.level == level)
+    if delivery_status:
+        conditions.append(SystemErrorEvent.delivery_status == delivery_status)
+    if undelivered_only:
+        conditions.append(SystemErrorEvent.delivery_status.in_(UNDELIVERED_STATUSES))
+    if logger_name:
+        conditions.append(SystemErrorEvent.logger_name.ilike(f'%{logger_name}%'))
+    if search:
+        pattern = f'%{search}%'
+        conditions.append(
+            or_(
+                SystemErrorEvent.event.ilike(pattern),
+                SystemErrorEvent.error_type.ilike(pattern),
+                SystemErrorEvent.logger_name.ilike(pattern),
+            )
+        )
+    if date_from:
+        conditions.append(SystemErrorEvent.created_at >= date_from)
+    if date_to:
+        conditions.append(SystemErrorEvent.created_at <= date_to)
+
+    count_query = select(func.count()).select_from(SystemErrorEvent)
+    query = select(SystemErrorEvent)
+    for condition in conditions:
+        count_query = count_query.where(condition)
+        query = query.where(condition)
+
+    total = (await db.execute(count_query)).scalar() or 0
+
+    query = query.order_by(SystemErrorEvent.created_at.desc()).limit(limit).offset(offset)
+    items = list((await db.execute(query)).scalars().all())
+
+    return items, total
+
+
+async def get_error_event(db: AsyncSession, event_id: int) -> SystemErrorEvent | None:
+    result = await db.execute(select(SystemErrorEvent).where(SystemErrorEvent.id == event_id))
+    return result.scalar_one_or_none()
+
+
+async def get_error_summary(db: AsyncSession) -> dict[str, Any]:
+    """Сводка для бейджа и шапки страницы."""
+    now = datetime.now(tz=UTC)
+    day_ago = now - timedelta(days=1)
+    week_ago = now - timedelta(days=7)
+
+    undelivered_total = (
+        await db.execute(
+            select(func.count())
+            .select_from(SystemErrorEvent)
+            .where(SystemErrorEvent.delivery_status.in_(UNDELIVERED_STATUSES))
+        )
+    ).scalar() or 0
+
+    last_24h = (
+        await db.execute(
+            select(func.count()).select_from(SystemErrorEvent).where(SystemErrorEvent.created_at >= day_ago)
+        )
+    ).scalar() or 0
+
+    last_7d = (
+        await db.execute(
+            select(func.count()).select_from(SystemErrorEvent).where(SystemErrorEvent.created_at >= week_ago)
+        )
+    ).scalar() or 0
+
+    by_status_rows = (
+        await db.execute(
+            select(SystemErrorEvent.delivery_status, func.count())
+            .where(SystemErrorEvent.created_at >= week_ago)
+            .group_by(SystemErrorEvent.delivery_status)
+        )
+    ).all()
+
+    top_rows = (
+        await db.execute(
+            select(SystemErrorEvent.error_type, SystemErrorEvent.event, func.count().label('cnt'))
+            .where(SystemErrorEvent.created_at >= week_ago)
+            .group_by(SystemErrorEvent.error_type, SystemErrorEvent.event)
+            .order_by(func.count().desc())
+            .limit(10)
+        )
+    ).all()
+
+    return {
+        'undelivered_total': undelivered_total,
+        'last_24h': last_24h,
+        'last_7d': last_7d,
+        'by_status_7d': {status or 'unknown': count for status, count in by_status_rows},
+        'top_errors_7d': [
+            {'error_type': error_type, 'event': event, 'count': count} for error_type, event, count in top_rows
+        ],
+    }
+
+
+async def mark_delivery_result(
+    db: AsyncSession,
+    event: SystemErrorEvent,
+    *,
+    delivered: bool,
+    error: str | None = None,
+) -> SystemErrorEvent:
+    """Записать исход ручной повторной доставки."""
+    event.delivery_attempts = (event.delivery_attempts or 0) + 1
+    event.last_attempt_at = datetime.now(tz=UTC)
+    if delivered:
+        event.delivery_status = 'sent'
+        event.delivered_at = datetime.now(tz=UTC)
+        event.delivery_error = None
+    else:
+        event.delivery_status = 'failed'
+        event.delivery_error = (error or '')[:1000] or None
+    await db.commit()
+    await db.refresh(event)
+    return event

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -4802,3 +4802,49 @@ class UserDeviceAlias(Base):
     alias = Column(String(64), nullable=False)
     created_at = Column(AwareDateTime(), server_default=func.now(), nullable=False)
     updated_at = Column(AwareDateTime(), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+
+class SystemErrorEvent(Base):
+    """Ошибки уровня error/critical со статусом доставки в админ-чат.
+
+    Пишется из ``TelegramNotifierProcessor`` ДО попытки отправки, поэтому
+    запись остаётся даже когда все пути до Telegram недоступны. Раньше такие
+    ошибки жили только в docker-логах: провал доставки намеренно логируется
+    как warning (иначе получается петля усиления), и наружу не всплывал.
+    """
+
+    __tablename__ = 'system_error_events'
+    __table_args__ = (
+        Index('ix_system_error_events_status_created', 'delivery_status', 'created_at'),
+        Index('ix_system_error_events_dedup_created', 'dedup_hash', 'created_at'),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    # Клиентский идентификатор: строка пишется асинхронно, поэтому в момент
+    # отправки id из БД ещё неизвестен — статус обновляется по event_uid.
+    event_uid = Column(String(32), unique=True, nullable=False, index=True)
+
+    created_at = Column(AwareDateTime(), server_default=func.now(), nullable=False, index=True)
+
+    # Что произошло
+    level = Column(String(16), nullable=False, default='error', index=True)
+    logger_name = Column(String(255), nullable=True, index=True)
+    event = Column(Text, nullable=False)
+    error_type = Column(String(255), nullable=True, index=True)
+    traceback = Column(Text, nullable=True)
+    context = Column(JSON, nullable=True)
+
+    # Telegram-id пользователя, если ошибка произошла в его контексте.
+    # Намеренно без ForeignKey: ошибка может ссылаться на ещё не созданного
+    # или уже удалённого пользователя, а падение записи об ошибке недопустимо.
+    user_id = Column(BigInteger, nullable=True, index=True)
+
+    dedup_hash = Column(String(32), nullable=True)
+
+    # Доставка: pending -> sent | failed | suppressed | skipped
+    delivery_status = Column(String(16), nullable=False, default='pending')
+    delivery_attempts = Column(Integer, nullable=False, default=0)
+    last_attempt_at = Column(AwareDateTime(), nullable=True)
+    delivered_at = Column(AwareDateTime(), nullable=True)
+    delivery_error = Column(Text, nullable=True)

--- a/app/logging_handler.py
+++ b/app/logging_handler.py
@@ -37,6 +37,51 @@ from aiogram import Bot
 RECENT_HASHES_MAX_SIZE: Final[int] = 256
 RECENT_HASH_TTL_SECONDS: Final[float] = 300.0  # 5 min — matches cooldown in global_error
 
+# Статусы доставки события об ошибке (см. system_error_log_service)
+STATUS_PENDING: Final[str] = 'pending'
+STATUS_SENT: Final[str] = 'sent'
+STATUS_FAILED: Final[str] = 'failed'
+STATUS_SUPPRESSED: Final[str] = 'suppressed'
+STATUS_SKIPPED: Final[str] = 'skipped'
+
+# Исход send_error_to_admin_chat -> статус записи в system_error_events
+_OUTCOME_TO_STATUS: Final[dict[str, str]] = {
+    'sent': STATUS_SENT,
+    'throttled': STATUS_SUPPRESSED,
+    'skipped': STATUS_SKIPPED,
+    'failed': STATUS_FAILED,
+}
+
+
+def _record_error_event(event_dict: dict[str, Any], dedup_hash: str | None, status: str) -> str | None:
+    """Записать событие об ошибке в БД.
+
+    Никогда не бросает и никогда не логирует на уровне error — иначе вызов
+    вернётся в этот же процессор и получится бесконечная рекурсия.
+    """
+    try:
+        from app.services.system_error_log_service import system_error_log_service
+
+        event_uid = system_error_log_service.record(event_dict, dedup_hash)
+        if event_uid and status != STATUS_PENDING:
+            system_error_log_service.mark(event_uid, status)
+        return event_uid
+    except Exception:
+        return None
+
+
+def _mark_error_event(event_uid: str | None, status: str, error: Any = None) -> None:
+    """Уточнить статус доставки. Тоже молча проглатывает любые сбои."""
+    if not event_uid:
+        return
+    try:
+        from app.services.system_error_log_service import system_error_log_service
+
+        system_error_log_service.mark(event_uid, status, error)
+    except Exception:
+        pass
+
+
 # Logger name prefixes we never want notifications from
 # (noisy transport-level loggers).
 IGNORED_LOGGER_PREFIXES: Final[tuple[str, ...]] = (
@@ -151,13 +196,17 @@ class TelegramNotifierProcessor:
         if level not in ('error', 'critical', 'exception'):
             return event_dict
 
-        # 2. Already sent via GlobalErrorMiddleware / @error_handler
-        if event_dict.get('_admin_notified'):
-            return event_dict
-
-        # 3. Filter noisy loggers
+        # 2. Filter noisy loggers
         logger_name = event_dict.get('logger', '')
         if any(logger_name.startswith(prefix) for prefix in IGNORED_LOGGER_PREFIXES):
+            return event_dict
+
+        # 3. Already sent via GlobalErrorMiddleware / @error_handler.
+        # Запись всё равно делаем: сюда же попадает сам провал доставки
+        # (`logger.error(..., _admin_notified=True)`), который раньше не
+        # всплывал нигде, кроме docker-логов.
+        if event_dict.get('_admin_notified'):
+            _record_error_event(event_dict, None, STATUS_SKIPPED)
             return event_dict
 
         # 4. Resolve exc_info into actual tuple while still in except block.
@@ -183,28 +232,37 @@ class TelegramNotifierProcessor:
                         event_dict['exc_info'] = (type(candidate), candidate, candidate.__traceback__)
                         break
 
+        # 4c. Персистим событие ДО любых отсечек и до попытки отправки.
+        # Дальше статус уточняется: подавлено / пропущено / отправлено / провал.
+        msg_hash = self._compute_hash(event_dict)
+        event_uid = _record_error_event(event_dict, msg_hash, STATUS_PENDING)
+
         # 4b. Skip transient RemnaWave panel failures (slow / briefly unreachable)
         # — forwarding them would spam the admin chat on every slow-panel request.
         if _is_transient_remnawave_error(event_dict):
+            _mark_error_event(event_uid, STATUS_SUPPRESSED)
             return event_dict
 
         # 5. Bot not initialized yet — skip
         bot = self._bot
         if bot is None:
+            _mark_error_event(event_uid, STATUS_SKIPPED)
             return event_dict
 
         # 6. Deduplication via hash
-        msg_hash = self._compute_hash(event_dict)
         now = time.monotonic()
 
         with self._lock:
             self._evict_stale(now)
             if msg_hash in self._recent_hashes:
+                # Дубликат в окне TTL: в чат не шлём, но запись уже есть —
+                # на странице в админке видно реальное число повторов.
+                _mark_error_event(event_uid, STATUS_SUPPRESSED)
                 return event_dict
             self._recent_hashes[msg_hash] = now
 
         # 7. Schedule async send
-        self._schedule_send(bot, event_dict)
+        self._schedule_send(bot, event_dict, event_uid)
 
         return event_dict
 
@@ -243,7 +301,7 @@ class TelegramNotifierProcessor:
             for k in sorted_keys[: len(self._recent_hashes) - RECENT_HASHES_MAX_SIZE]:
                 self._recent_hashes.pop(k, None)
 
-    def _schedule_send(self, bot: Bot, event_dict: dict[str, Any]) -> None:
+    def _schedule_send(self, bot: Bot, event_dict: dict[str, Any], event_uid: str | None = None) -> None:
         """Schedule async delivery via event loop.
 
         Works from any thread:
@@ -256,22 +314,24 @@ class TelegramNotifierProcessor:
             # No running loop — silently skip.
             # The structlog processor runs in sync context; if there's no loop,
             # we can't send anything.
+            _mark_error_event(event_uid, STATUS_SKIPPED, 'no running event loop')
             return
         else:
             # We're in async context — create task directly
-            self._create_send_task(bot, event_dict, loop)
+            self._create_send_task(bot, event_dict, loop, event_uid)
 
     def _create_send_task(
         self,
         bot: Bot,
         event_dict: dict[str, Any],
         loop: asyncio.AbstractEventLoop,
+        event_uid: str | None = None,
     ) -> None:
         """Create an asyncio.Task for sending the notification."""
-        loop.create_task(self._send(bot, event_dict))
+        loop.create_task(self._send(bot, event_dict, event_uid))
 
     @staticmethod
-    async def _send(bot: Bot, event_dict: dict[str, Any]) -> None:
+    async def _send(bot: Bot, event_dict: dict[str, Any], event_uid: str | None = None) -> None:
         """Send the log event to the admin chat via existing infrastructure."""
         try:
             # Lazy import to avoid circular dependencies at startup
@@ -311,12 +371,13 @@ class TelegramNotifierProcessor:
             if error.args:
                 error.args = tuple(_redact_telegram_secrets(arg) if isinstance(arg, str) else arg for arg in error.args)
 
-            await send_error_to_admin_chat(bot, error, context, tb_override=tb_override)
+            outcome = await send_error_to_admin_chat(bot, error, context, tb_override=tb_override)
+            _mark_error_event(event_uid, _OUTCOME_TO_STATUS.get(outcome, STATUS_FAILED))
 
-        except Exception:
+        except Exception as send_error:
             # Never let an exception leak — this is a logging processor,
             # recursion would kill the application.
-            pass
+            _mark_error_event(event_uid, STATUS_FAILED, send_error)
 
 
 def _make_event_dict_error(event_dict: dict[str, Any]) -> Exception:

--- a/app/middlewares/global_error.py
+++ b/app/middlewares/global_error.py
@@ -236,7 +236,7 @@ def _build_rich_error_report(now: datetime, error_type: str, context: str) -> st
 
 async def send_error_to_admin_chat(
     bot: Bot, error: Exception, context: str = '', tb_override: str | None = None
-) -> bool:
+) -> str:
     """
     Отправляет уведомление об ошибке в админский чат с троттлингом.
 
@@ -247,7 +247,12 @@ async def send_error_to_admin_chat(
         tb_override: Готовый traceback (если вызывается не из except-блока)
 
     Returns:
-        bool: True если уведомление отправлено
+        str: исход доставки — 'sent' | 'throttled' | 'skipped' | 'failed'.
+
+        Раньше возвращался bool, но False означал сразу три разных вещи:
+        уведомления выключены, сработал троттлинг, реальный провал отправки.
+        Для записи в system_error_events их надо различать — иначе штатное
+        подавление дубликата выглядит как авария.
     """
     global _last_error_notification
 
@@ -259,7 +264,7 @@ async def send_error_to_admin_chat(
     enabled = getattr(settings, 'ADMIN_NOTIFICATIONS_ENABLED', False)
 
     if not enabled or not chat_id:
-        return False
+        return 'skipped'
 
     error_type = type(error).__name__
     error_message = str(error)[:ERROR_MESSAGE_MAX_LENGTH]
@@ -276,7 +281,7 @@ async def send_error_to_admin_chat(
     now = datetime.now(tz=UTC)
     if _last_error_notification and (now - _last_error_notification) < _error_notification_cooldown:
         logger.debug('Ошибка добавлена в буфер, троттлинг активен', error_type=error_type)
-        return False
+        return 'throttled'
 
     _last_error_notification = now
 
@@ -302,7 +307,7 @@ async def send_error_to_admin_chat(
         ):
             _error_buffer.clear()
             logger.info('Rich-уведомление об ошибке отправлено в чат', chat_id=chat_id)
-            return True
+            return 'sent'
     except Exception as rich_error:
         # warning + строка: error-уровень отсюда сам бы ушёл в этот конвейер
         logger.warning('Сбой rich-рендера отчёта об ошибке', error=str(rich_error))
@@ -374,8 +379,8 @@ async def send_error_to_admin_chat(
         await bot.send_document(**message_kwargs)
         _error_buffer.clear()  # Clear only after successful send
         logger.info('Уведомление об ошибке отправлено в чат', chat_id=chat_id)
-        return True
+        return 'sent'
 
     except Exception as e:
         logger.error('Ошибка отправки уведомления об ошибке', e=e, _admin_notified=True)
-        return False
+        return 'failed'

--- a/app/services/permission_service.py
+++ b/app/services/permission_service.py
@@ -75,6 +75,7 @@ PERMISSION_REGISTRY: dict[str, list[str]] = {
     'settings': ['read', 'edit'],
     'roles': ['read', 'create', 'edit', 'delete', 'assign'],
     'audit_log': ['read', 'export'],
+    'system_errors': ['read', 'manage'],
     'channels': ['read', 'edit'],
     'ban_system': ['read', 'edit', 'ban', 'unban'],
     'wheel': ['read', 'edit'],

--- a/app/services/rbac_bootstrap_service.py
+++ b/app/services/rbac_bootstrap_service.py
@@ -196,6 +196,7 @@ _PRESET_ROLES: list[dict] = [
             'landings:create',
             'landings:edit',
             'landings:delete',
+            'system_errors:*',
         ],
         'color': '#F59E0B',
         'icon': 'crown',

--- a/app/services/system_error_log_service.py
+++ b/app/services/system_error_log_service.py
@@ -1,0 +1,289 @@
+"""Персистентное хранилище ошибок приложения со статусом доставки.
+
+Зачем: провал доставки уведомления в админ-чат намеренно логируется как
+``warning``, а не ``error`` — иначе ``TelegramNotifierProcessor`` попробует
+переслать эту ошибку в тот же недоступный чат и получится петля усиления.
+Следствие: когда канал до Telegram лежит, ошибки не всплывают нигде. Этот
+сервис пишет их в БД ДО попытки отправки, поэтому запись переживает отказ
+любого числа путей доставки.
+
+Все ошибки самого сервиса логируются через ``logger.warning`` — уровень
+``error`` отсюда снова ушёл бы в тот же конвейер и вызвал рекурсию.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import delete, insert, update
+
+from app.database.database import AsyncSessionLocal
+from app.database.models import SystemErrorEvent
+
+
+logger = structlog.get_logger(__name__)
+
+# Очередь ограничена намеренно: при шторме ошибок лучше потерять хвост, чем
+# съесть память процесса. Потери считаются и видны в логе.
+QUEUE_MAX_SIZE = 1000
+
+# Ограничения на размер полей, чтобы одна ошибка с гигантским трейсбеком
+# не раздула таблицу.
+MAX_EVENT_LEN = 4000
+MAX_TRACEBACK_LEN = 20000
+MAX_ERROR_TYPE_LEN = 255
+MAX_LOGGER_LEN = 255
+
+RETENTION_DAYS = 30
+CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60
+
+# Статусы доставки
+STATUS_PENDING = 'pending'
+STATUS_SENT = 'sent'
+STATUS_FAILED = 'failed'
+STATUS_SUPPRESSED = 'suppressed'
+STATUS_SKIPPED = 'skipped'
+
+
+def _truncate(value: Any, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = value if isinstance(value, str) else str(value)
+    return text[:limit]
+
+
+class SystemErrorLogService:
+    """Фоновый писатель событий об ошибках в БД."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[tuple[str, dict[str, Any]]] | None = None
+        self._worker: asyncio.Task | None = None
+        self._cleanup_worker: asyncio.Task | None = None
+        self._dropped = 0
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    # ------------------------------------------------------------------
+    # Жизненный цикл
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        if self._worker and not self._worker.done():
+            return
+        self._loop = asyncio.get_running_loop()
+        self._queue = asyncio.Queue(maxsize=QUEUE_MAX_SIZE)
+        self._worker = asyncio.create_task(self._run())
+        self._cleanup_worker = asyncio.create_task(self._run_cleanup())
+        logger.info('SystemErrorLogService запущен', queue_max_size=QUEUE_MAX_SIZE)
+
+    async def stop(self) -> None:
+        for task in (self._worker, self._cleanup_worker):
+            if task and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        self._worker = None
+        self._cleanup_worker = None
+
+    @property
+    def is_running(self) -> bool:
+        return bool(self._worker and not self._worker.done())
+
+    # ------------------------------------------------------------------
+    # Публичный API — вызывается из синхронного лог-конвейера
+    # ------------------------------------------------------------------
+
+    def record(self, event_dict: dict[str, Any], dedup_hash: str | None = None) -> str | None:
+        """Поставить событие в очередь на запись. Возвращает event_uid.
+
+        Безопасно для вызова из синхронного кода: при переполнении очереди или
+        отсутствии живого воркера просто возвращает None, ничего не бросая.
+        """
+        try:
+            event_uid = uuid.uuid4().hex
+            payload = self._build_payload(event_dict, event_uid, dedup_hash)
+            if not self._enqueue('insert', payload):
+                return None
+            return event_uid
+        except Exception as e:  # никогда не мешаем работе приложения
+            self._warn('Не удалось поставить ошибку в очередь записи', e)
+            return None
+
+    def mark(self, event_uid: str | None, status: str, error: Any = None) -> None:
+        """Обновить статус доставки ранее записанного события."""
+        if not event_uid:
+            return
+        try:
+            self._enqueue(
+                'status',
+                {
+                    'event_uid': event_uid,
+                    'status': status,
+                    'error': _truncate(error, 1000),
+                },
+            )
+        except Exception as e:
+            self._warn('Не удалось поставить обновление статуса в очередь', e)
+
+    # ------------------------------------------------------------------
+    # Внутреннее
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _warn(message: str, error: Any = None) -> None:
+        """ВАЖНО: только warning. logger.error отсюда уйдёт в
+        TelegramNotifierProcessor, тот снова позовёт этот сервис — рекурсия.
+        """
+        try:
+            logger.warning(message, error=str(error)[:200] if error else None)
+        except Exception:
+            pass
+
+    def _put_nowait(self, op: str, payload: dict[str, Any]) -> bool:
+        queue = self._queue
+        if queue is None:
+            return False
+        try:
+            queue.put_nowait((op, payload))
+            return True
+        except asyncio.QueueFull:
+            self._dropped += 1
+            if self._dropped % 100 == 1:
+                self._warn(f'Очередь записи ошибок переполнена, потеряно событий: {self._dropped}')
+            return False
+
+    def _enqueue(self, op: str, payload: dict[str, Any]) -> bool:
+        """Поставить операцию в очередь из любого потока.
+
+        ``asyncio.Queue`` не потокобезопасна, а ошибки логируются в том числе
+        из пула потоков (``run_in_executor``). Поэтому из чужого потока кладём
+        через ``call_soon_threadsafe``, а не напрямую.
+        """
+        loop = self._loop
+        if self._queue is None or loop is None:
+            return False
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            return self._put_nowait(op, payload)
+
+        try:
+            loop.call_soon_threadsafe(self._put_nowait, op, payload)
+            return True
+        except RuntimeError:
+            # Цикл уже закрыт — записывать некуда, но падать нельзя.
+            return False
+
+    @staticmethod
+    def _build_payload(event_dict: dict[str, Any], event_uid: str, dedup_hash: str | None) -> dict[str, Any]:
+        exc_info = event_dict.get('exc_info')
+        error_type: str | None = None
+        traceback_text: str | None = None
+
+        if isinstance(exc_info, tuple) and len(exc_info) == 3:
+            if exc_info[0] is not None:
+                error_type = exc_info[0].__name__
+            if exc_info[2] is not None:
+                import traceback as tb_module
+
+                traceback_text = ''.join(tb_module.format_exception(*exc_info))
+
+        if error_type is None:
+            candidate = event_dict.get('error')
+            if isinstance(candidate, BaseException):
+                error_type = type(candidate).__name__
+
+        # Контекст: всё, что не служебное и сериализуемо в строку.
+        skip_keys = {'exc_info', 'event', 'level', 'logger', 'timestamp', '_admin_notified'}
+        context: dict[str, str] = {}
+        for key, value in event_dict.items():
+            if key in skip_keys:
+                continue
+            try:
+                context[str(key)[:64]] = str(value)[:500]
+            except Exception:
+                continue
+
+        raw_user_id = event_dict.get('user_id')
+        try:
+            user_id = int(raw_user_id) if raw_user_id is not None else None
+        except (TypeError, ValueError):
+            user_id = None
+
+        return {
+            'event_uid': event_uid,
+            'level': _truncate(event_dict.get('level', 'error'), 16),
+            'logger_name': _truncate(event_dict.get('logger'), MAX_LOGGER_LEN),
+            'event': _truncate(event_dict.get('event', ''), MAX_EVENT_LEN) or '',
+            'error_type': _truncate(error_type, MAX_ERROR_TYPE_LEN),
+            'traceback': _truncate(traceback_text, MAX_TRACEBACK_LEN),
+            'context': context or None,
+            'user_id': user_id,
+            'dedup_hash': _truncate(dedup_hash, 32),
+            'delivery_status': STATUS_PENDING,
+            'delivery_attempts': 0,
+        }
+
+    async def _run(self) -> None:
+        queue = self._queue
+        if queue is None:
+            return
+        while True:
+            try:
+                op, payload = await queue.get()
+            except asyncio.CancelledError:
+                raise
+            try:
+                await self._apply(op, payload)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self._warn('Сбой записи события об ошибке в БД', e)
+            finally:
+                queue.task_done()
+
+    async def _apply(self, op: str, payload: dict[str, Any]) -> None:
+        async with AsyncSessionLocal() as session:
+            if op == 'insert':
+                await session.execute(insert(SystemErrorEvent).values(**payload))
+            elif op == 'status':
+                values: dict[str, Any] = {
+                    'delivery_status': payload['status'],
+                    'last_attempt_at': datetime.now(tz=UTC),
+                    'delivery_attempts': SystemErrorEvent.delivery_attempts + 1,
+                }
+                if payload['status'] == STATUS_SENT:
+                    values['delivered_at'] = datetime.now(tz=UTC)
+                    values['delivery_error'] = None
+                elif payload.get('error'):
+                    values['delivery_error'] = payload['error']
+                await session.execute(
+                    update(SystemErrorEvent).where(SystemErrorEvent.event_uid == payload['event_uid']).values(**values)
+                )
+            await session.commit()
+
+    async def _run_cleanup(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
+                cutoff = datetime.now(tz=UTC) - timedelta(days=RETENTION_DAYS)
+                async with AsyncSessionLocal() as session:
+                    result = await session.execute(delete(SystemErrorEvent).where(SystemErrorEvent.created_at < cutoff))
+                    await session.commit()
+                if result.rowcount:
+                    logger.info('Очищены старые записи об ошибках', deleted=result.rowcount, days=RETENTION_DAYS)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self._warn('Сбой очистки старых записей об ошибках', e)
+
+
+system_error_log_service = SystemErrorLogService()

--- a/app/services/system_error_log_service.py
+++ b/app/services/system_error_log_service.py
@@ -50,11 +50,29 @@ STATUS_SUPPRESSED = 'suppressed'
 STATUS_SKIPPED = 'skipped'
 
 
+def _redact(text: str) -> str:
+    """Вырезать Telegram-токены перед записью в БД.
+
+    Тот же фильтр, что применяется на пути в админ-чат: aiohttp кладёт в
+    сообщение и трейсбек полный URL вида ``.../bot<TOKEN>/sendMessage``. Без
+    него журнал складывал бы токен бота в открытом виде в таблицу и отдавал
+    его наружу через ``GET /admin/system-errors/{id}``.
+    """
+    try:
+        from app.services.admin_notification_service import _redact_telegram_secrets
+
+        return _redact_telegram_secrets(text)
+    except Exception:
+        # Молча: error-уровень отсюда вернулся бы в тот же конвейер. Лучше
+        # потерять запись, чем записать секрет.
+        return ''
+
+
 def _truncate(value: Any, limit: int) -> str | None:
     if value is None:
         return None
     text = value if isinstance(value, str) else str(value)
-    return text[:limit]
+    return _redact(text)[:limit]
 
 
 class SystemErrorLogService:
@@ -80,7 +98,18 @@ class SystemErrorLogService:
         self._cleanup_worker = asyncio.create_task(self._run_cleanup())
         logger.info('SystemErrorLogService запущен', queue_max_size=QUEUE_MAX_SIZE)
 
-    async def stop(self) -> None:
+    async def stop(self, drain_timeout: float = 5.0) -> None:
+        """Дописать то, что уже в очереди, и остановить воркеров.
+
+        Слив обязателен: при аварийном завершении в очереди лежат ровно те
+        ошибки, которые к этому завершению и привели. Отмена воркера без слива
+        выбросила бы их — то есть самый ценный случай журнал бы и потерял.
+        """
+        queue = self._queue
+        if queue is not None and self._worker and not self._worker.done():
+            with contextlib.suppress(TimeoutError, asyncio.TimeoutError):
+                await asyncio.wait_for(queue.join(), timeout=drain_timeout)
+
         for task in (self._worker, self._cleanup_worker):
             if task and not task.done():
                 task.cancel()
@@ -208,7 +237,7 @@ class SystemErrorLogService:
             if key in skip_keys:
                 continue
             try:
-                context[str(key)[:64]] = str(value)[:500]
+                context[str(key)[:64]] = _redact(str(value))[:500]
             except Exception:
                 continue
 
@@ -255,11 +284,14 @@ class SystemErrorLogService:
             if op == 'insert':
                 await session.execute(insert(SystemErrorEvent).values(**payload))
             elif op == 'status':
-                values: dict[str, Any] = {
-                    'delivery_status': payload['status'],
-                    'last_attempt_at': datetime.now(tz=UTC),
-                    'delivery_attempts': SystemErrorEvent.delivery_attempts + 1,
-                }
+                values: dict[str, Any] = {'delivery_status': payload['status']}
+                # Попыткой считается только реальная отправка. suppressed
+                # (дубликат в окне TTL) и skipped (бот не поднят, канал выключен)
+                # до Telegram не доходят, и счётчик «сколько раз пытались» на них
+                # врал бы — админ читает его, чтобы понять, пробовали ли вообще.
+                if payload['status'] in (STATUS_SENT, STATUS_FAILED):
+                    values['last_attempt_at'] = datetime.now(tz=UTC)
+                    values['delivery_attempts'] = SystemErrorEvent.delivery_attempts + 1
                 if payload['status'] == STATUS_SENT:
                     values['delivered_at'] = datetime.now(tz=UTC)
                     values['delivery_error'] = None

--- a/main.py
+++ b/main.py
@@ -321,6 +321,12 @@ async def main():
         daily_subscription_service.set_bot(bot)
         telegram_notifier.set_bot(bot)
 
+        # Хранилище ошибок: пишет события ДО попытки доставки в Telegram,
+        # поэтому они переживают недоступность всех путей до чата.
+        from app.services.system_error_log_service import system_error_log_service
+
+        await system_error_log_service.start()
+
         from app.services.channel_subscription_service import channel_subscription_service
 
         channel_subscription_service.bot = bot

--- a/main.py
+++ b/main.py
@@ -957,6 +957,15 @@ async def main():
             except Exception as e:
                 logger.error('Ошибка остановки сервиса ротации логов', error=e)
 
+        logger.info('ℹ️ Остановка журнала системных ошибок...')
+        try:
+            from app.services.system_error_log_service import system_error_log_service
+
+            await system_error_log_service.stop()
+        except Exception as e:
+            # warning: error отсюда ушёл бы в тот же конвейер, который мы гасим
+            logger.warning('Ошибка остановки журнала системных ошибок', error=e)
+
         logger.info('ℹ️ Остановка очереди чеков NaloGO...')
         try:
             await nalogo_queue_service.stop()

--- a/migrations/alembic/versions/0111_create_system_error_events.py
+++ b/migrations/alembic/versions/0111_create_system_error_events.py
@@ -1,0 +1,51 @@
+"""create system_error_events table
+
+Revision ID: 0111
+Revises: 0110
+Create Date: 2026-08-28
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '0111'
+down_revision: Union[str, None] = '0110'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'system_error_events',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('event_uid', sa.String(32), unique=True, nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('level', sa.String(16), nullable=False, server_default='error'),
+        sa.Column('logger_name', sa.String(255), nullable=True),
+        sa.Column('event', sa.Text(), nullable=False),
+        sa.Column('error_type', sa.String(255), nullable=True),
+        sa.Column('traceback', sa.Text(), nullable=True),
+        sa.Column('context', sa.JSON(), nullable=True),
+        sa.Column('user_id', sa.BigInteger(), nullable=True),
+        sa.Column('dedup_hash', sa.String(32), nullable=True),
+        sa.Column('delivery_status', sa.String(16), nullable=False, server_default='pending'),
+        sa.Column('delivery_attempts', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('last_attempt_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('delivered_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('delivery_error', sa.Text(), nullable=True),
+    )
+    op.create_index('ix_system_error_events_event_uid', 'system_error_events', ['event_uid'], unique=True)
+    op.create_index('ix_system_error_events_created_at', 'system_error_events', ['created_at'])
+    op.create_index('ix_system_error_events_level', 'system_error_events', ['level'])
+    op.create_index('ix_system_error_events_logger_name', 'system_error_events', ['logger_name'])
+    op.create_index('ix_system_error_events_error_type', 'system_error_events', ['error_type'])
+    op.create_index('ix_system_error_events_user_id', 'system_error_events', ['user_id'])
+    op.create_index('ix_system_error_events_status_created', 'system_error_events', ['delivery_status', 'created_at'])
+    op.create_index('ix_system_error_events_dedup_created', 'system_error_events', ['dedup_hash', 'created_at'])
+
+
+def downgrade() -> None:
+    op.drop_table('system_error_events')

--- a/tests/cabinet/test_system_errors_permissions.py
+++ b/tests/cabinet/test_system_errors_permissions.py
@@ -1,0 +1,57 @@
+"""Права журнала системных ошибок должны быть в PERMISSION_REGISTRY.
+
+``require_permission('system_errors:read')`` работает и без регистрации — проверка
+идёт по строке. А вот редактор ролей валидирует список по реестру: незнакомое
+право отдаёт 400. Поэтому без записи в реестре страницу нельзя выдать никакой
+роли, и — хуже — сохранение роли, которой bootstrap уже проставил
+``system_errors:*``, падает с 400 на ровном месте.
+
+Ратчет на каждое право, которое проверяют роуты кабинета: тот же класс промаха,
+что был у ``users:send_message`` и ``coupons:*``.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.cabinet.routes.admin_roles import _validate_permissions
+from app.services.permission_service import PERMISSION_REGISTRY, get_all_permissions
+from app.services.rbac_bootstrap_service import _PRESET_ROLES
+
+
+SYSTEM_ERROR_PERMISSIONS = ('system_errors:read', 'system_errors:manage')
+
+
+def test_section_is_registered():
+    assert 'system_errors' in PERMISSION_REGISTRY
+
+
+@pytest.mark.parametrize('permission', SYSTEM_ERROR_PERMISSIONS)
+def test_permission_is_grantable(permission):
+    assert permission in get_all_permissions()
+    _validate_permissions([permission])
+
+
+def test_wildcard_from_bootstrap_survives_a_role_save():
+    """Bootstrap раздаёт ``system_errors:*`` — редактор ролей обязан его принять."""
+    _validate_permissions(['system_errors:*'])
+
+
+def test_every_permission_required_by_cabinet_routes_is_registered():
+    """Ратчет: право, проверяемое роутом, но не заведённое в реестре, не выдать никому."""
+    used: set[str] = set()
+    for path in Path('app/cabinet/routes').rglob('*.py'):
+        used |= set(re.findall(r"require_permission\(\s*'([a-z_]+:[a-z_*]+)'", path.read_text()))
+
+    known = set(get_all_permissions()) | {f'{section}:*' for section in PERMISSION_REGISTRY} | {'*:*'}
+    assert not (used - known), f'права проверяются, но не заведены в PERMISSION_REGISTRY: {sorted(used - known)}'
+
+
+def test_bootstrap_roles_only_grant_registered_permissions():
+    """То же с другой стороны: роль из bootstrap должна проходить валидацию редактора."""
+    known = set(get_all_permissions()) | {f'{section}:*' for section in PERMISSION_REGISTRY} | {'*:*'}
+
+    for role in _PRESET_ROLES:
+        unknown = set(role.get('permissions', [])) - known
+        assert not unknown, f'роль {role.get("name")} раздаёт незарегистрированные права: {sorted(unknown)}'

--- a/tests/middlewares/test_rich_error_report.py
+++ b/tests/middlewares/test_rich_error_report.py
@@ -54,7 +54,7 @@ async def test_send_error_uses_rich_and_clears_buffer():
 
     sent = await ge.send_error_to_admin_chat(bot, ValueError('boom'), context='Logger: app.x')
 
-    assert sent is True
+    assert sent == 'sent'
     bot.send_rich_message.assert_awaited_once()
     bot.send_document.assert_not_awaited()  # файл не нужен — всё инлайн
     assert ge._error_buffer == []
@@ -69,6 +69,6 @@ async def test_send_error_falls_back_to_document_when_rich_unavailable(monkeypat
 
     sent = await ge.send_error_to_admin_chat(bot, ValueError('boom'))
 
-    assert sent is True
+    assert sent == 'sent'
     bot.send_rich_message.assert_not_awaited()
     bot.send_document.assert_awaited_once()  # классический путь с .txt-файлом

--- a/tests/services/test_system_error_log_service.py
+++ b/tests/services/test_system_error_log_service.py
@@ -1,0 +1,117 @@
+"""Журнал системных ошибок: редактирование секретов, учёт попыток, слив очереди.
+
+Журнал пишет ошибку в БД до попытки доставки и отдаёт её через
+``GET /admin/system-errors/{id}``. Это второй путь наружу для тех же данных,
+которые на пути в Telegram проходят через ``_redact_telegram_secrets`` — значит,
+фильтр обязан стоять и здесь, иначе токен бота ложится в таблицу открытым
+текстом и уезжает в HTTP-ответ.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.system_error_log_service import (
+    STATUS_FAILED,
+    STATUS_SENT,
+    STATUS_SKIPPED,
+    STATUS_SUPPRESSED,
+    SystemErrorLogService,
+)
+
+
+TOKEN = '8521897198:AAHnQ1exampleTOKENvalue_0123456789abcd'
+
+
+def _event_dict_with_token() -> dict:
+    try:
+        raise RuntimeError(f'POST https://api.telegram.org/bot{TOKEN}/sendMessage failed')
+    except RuntimeError:
+        import sys
+
+        return {
+            'event': f'request to https://api.telegram.org/bot{TOKEN}/getMe failed',
+            'level': 'error',
+            'logger': 'app.x',
+            'exc_info': sys.exc_info(),
+            'url': f'https://api.telegram.org/bot{TOKEN}/sendMessage',
+        }
+
+
+# ============ редактирование секретов ============
+
+
+def test_token_is_redacted_in_every_persisted_field():
+    payload = SystemErrorLogService._build_payload(_event_dict_with_token(), 'uid1', None)
+
+    assert TOKEN not in (payload['event'] or '')
+    assert TOKEN not in (payload['traceback'] or '')
+    assert TOKEN not in str(payload['context'])
+    assert '[REDACTED]' in payload['event']
+
+
+def test_redaction_keeps_the_rest_of_the_message():
+    payload = SystemErrorLogService._build_payload(
+        {'event': 'connection to panel refused', 'level': 'error', 'logger': 'app.y'}, 'uid2', None
+    )
+    assert payload['event'] == 'connection to panel refused'
+
+
+# ============ учёт попыток доставки ============
+
+
+@pytest.mark.parametrize(
+    ('status', 'counted'),
+    [
+        (STATUS_SENT, True),
+        (STATUS_FAILED, True),
+        (STATUS_SUPPRESSED, False),
+        (STATUS_SKIPPED, False),
+    ],
+)
+async def test_only_real_delivery_attempts_are_counted(status, counted):
+    """suppressed/skipped до Telegram не доходят — счётчик попыток они не двигают."""
+    service = SystemErrorLogService()
+    captured: list = []
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=lambda stmt: captured.append(stmt))
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch('app.services.system_error_log_service.AsyncSessionLocal', return_value=session):
+        await service._apply('status', {'event_uid': 'uid', 'status': status, 'error': None})
+
+    values = captured[0].compile().params
+    assert ('delivery_attempts' in str(captured[0])) is counted, (
+        f'{status}: delivery_attempts {"должен" if counted else "не должен"} обновляться'
+    )
+    assert values['delivery_status'] == status
+
+
+# ============ слив очереди при остановке ============
+
+
+async def test_stop_flushes_what_is_already_queued():
+    """При аварийном завершении в очереди лежат ровно те ошибки, что к нему привели."""
+    service = SystemErrorLogService()
+    applied: list = []
+
+    async def fake_apply(op, payload):
+        applied.append((op, payload.get('event_uid')))
+
+    await service.start()
+    try:
+        with patch.object(service, '_apply', fake_apply):
+            uid = service.record({'event': 'boom', 'level': 'error', 'logger': 'app.z'})
+            assert uid is not None
+            await service.stop()
+    finally:
+        await service.stop()
+
+    assert applied == [('insert', uid)], 'событие из очереди должно быть записано до остановки'
+
+
+async def test_stop_is_safe_without_start():
+    await SystemErrorLogService().stop()


### PR DESCRIPTION
## Проблема

Провал доставки уведомления в админ-чат намеренно логируется как `warning`, а не `error` — иначе `TelegramNotifierProcessor` попробует переслать эту ошибку в тот же недоступный чат и получится петля усиления. Логика верная, но следствие неприятное: **когда канал до Telegram лежит, ошибки не всплывают нигде**, кроме docker-логов.

`_error_buffer` в `global_error` их частично копит, но он живёт в памяти процесса, ограничен по размеру, а троттлинг взводится **до** попытки отправки — так что во время обрыва большинство ошибок даже не пытается уйти.

## Решение

Событие пишется в `system_error_events` **до** попытки отправки, а статус уточняется после: `sent` / `failed` / `suppressed` / `skipped`. Запись переживает недоступность канала и рестарт процесса.

Дубликаты и подавленные события тоже записываются — со своим статусом, поэтому виден реальный масштаб повтора, а не одна строка на пять минут.

## Что внутри

- новая таблица `system_error_events` (миграция `0111`);
- `SystemErrorLogService` — ограниченная очередь плюс фоновый писатель. Все свои сбои логирует **только** через `warning`: `error` отсюда вернулся бы в тот же конвейер и дал рекурсию;
- постановка в очередь потокобезопасна — логи прилетают в том числе из `run_in_executor`, а `asyncio.Queue` таковой не является;
- API `/cabinet/admin/system-errors`: список с фильтрами, деталь с трейсбеком, сводка, ручная повторная отправка; право `system_errors:*`.

## Ломающее изменение

`send_error_to_admin_chat` возвращает строку исхода (`'sent' | 'throttled' | 'skipped' | 'failed'`) вместо `bool`. `False` означал сразу три разных вещи — уведомления выключены, сработал троттлинг, реальный провал, — а для журнала их надо различать, иначе штатное подавление дубликата выглядит как авария. Вызывающий в кодовой базе один, тест обновлён.

## Проверки

`pytest` — 5012 прошли, 0 упало. `ruff check` и `ruff format --check` по всей репе — чисто.

Функционал обкатан в бою: запись создаётся до отправки, статус проставляется после, ручная повторная отправка работает.

Парный PR во фронтенде кабинета добавляет страницу для этого API.
