### PR TITLE
fix(wheel): один PATCH на спин и снятие залипшего LIMITED

### DIFF
--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -685,6 +685,69 @@ class SubscriptionService:
             await self._reset_user_traffic(api, updated_user.id, user, reset_reason)
         return updated_user
 
+    @staticmethod
+    async def _clear_stale_limited_status(
+        api: Any,
+        remnawave_id: int,
+        updated_user: Any,
+        *,
+        intended_active: bool,
+    ) -> Any:
+        """Снять LIMITED, залипший из-за гонки с кроном панели.
+
+        ``findExceededUsers`` в Remnawave крутится по ``*/45 * * * * *`` и ставит
+        LIMITED всем, у кого ``status=ACTIVE AND usedTraffic >= trafficLimit``.
+        Если он сработает между чтением и записью нашего PATCH, юзер останется
+        LIMITED уже с поднятым лимитом: ``users.service.ts::updateUser`` снимает
+        статус только когда до записи юзер был не ACTIVE либо был LIMITED и лимит
+        вырос — в окне гонки не выполняется ни то, ни другое. Обратного пересчёта
+        «used < limit ⇒ снять LIMITED» в панели нет ни в одном кроне, поэтому
+        состояние залипает навсегда: VPN не работает, лечится только руками.
+
+        Дожимаем ``enable`` только когда доказано, что лимит уже больше
+        израсходованного: воскресить реально исчерпавшего трафик хуже, чем
+        оставить как есть.
+        """
+        if not intended_active or getattr(updated_user, 'status', None) is not UserStatus.LIMITED:
+            return updated_user
+
+        limit_bytes = getattr(updated_user, 'traffic_limit_bytes', 0) or 0
+
+        used_bytes: int | None = None
+        traffic = getattr(updated_user, 'user_traffic', None)
+        if traffic is not None:
+            used_bytes = getattr(traffic, 'used_traffic_bytes', None)
+
+        if used_bytes is None and limit_bytes > 0:
+            # Ответ на PATCH не обязан содержать userTraffic — спрашиваем отдельно.
+            try:
+                fresh = await api.get_user_by_id(remnawave_id)
+            except Exception as e:
+                logger.warning('Не удалось перечитать расход трафика из панели', remnawave_id=remnawave_id, error=e)
+                fresh = None
+            fresh_traffic = getattr(fresh, 'user_traffic', None) if fresh is not None else None
+            if fresh_traffic is not None:
+                used_bytes = getattr(fresh_traffic, 'used_traffic_bytes', None)
+
+        # limit_bytes == 0 — безлимит: LIMITED при нём бессмысленен в любом случае.
+        if limit_bytes > 0 and (used_bytes is None or used_bytes >= limit_bytes):
+            return updated_user
+
+        try:
+            enabled = await api.enable_user(remnawave_id)
+        except Exception as e:
+            # Операция уже закоммичена вызывающим кодом — падать здесь нельзя.
+            logger.error('Не удалось снять залипший LIMITED в панели', remnawave_id=remnawave_id, error=e)
+            return updated_user
+
+        logger.info(
+            'Снят LIMITED, выставленный кроном панели поверх поднятого лимита',
+            remnawave_id=remnawave_id,
+            limit_bytes=limit_bytes,
+            used_bytes=used_bytes,
+        )
+        return enabled or updated_user
+
     async def update_remnawave_user(
         self,
         db: AsyncSession,
@@ -857,6 +920,14 @@ class SubscriptionService:
                     updated_user = await api.update_user(**update_kwargs)
                 if updated_user is None:
                     raise RemnaWaveAPIError('Remnawave returned no user after subscription renewal update')
+
+                # Крон панели мог поставить LIMITED прямо в окне этого PATCH —
+                # тогда лимит запишется, а статус останется. Лечим здесь, а не в
+                # вызывающем коде: так закрыты все повышения лимита разом
+                # (колесо, докупка трафика, смена тарифа).
+                updated_user = await self._clear_stale_limited_status(
+                    api, remnawave_id, updated_user, intended_active=is_actually_active
+                )
 
                 if reset_traffic:
                     if settings.is_multi_tariff_enabled():

--- a/app/services/wheel_service.py
+++ b/app/services/wheel_service.py
@@ -328,8 +328,40 @@ class FortuneWheelService:
 
         return kopeks
 
+    @staticmethod
+    def _defer_panel_sync(pending: dict[int, Subscription] | None, subscription: Subscription) -> None:
+        """Отложить синк подписки до конца спина.
+
+        Ключ — id подписки: за один спин её трогают и списание, и приз, а PATCH
+        должен уйти один и уже с финальным состоянием.
+        """
+        if pending is None:
+            return
+        pending[subscription.id] = subscription
+
+    @staticmethod
+    async def _flush_panel_sync(db: AsyncSession, pending: dict[int, Subscription]) -> None:
+        """Один PATCH на каждую затронутую подписку — после всех изменений."""
+        if not pending:
+            return
+        subscription_service = SubscriptionService()
+        for subscription in pending.values():
+            try:
+                result = await subscription_service.update_remnawave_user(db, subscription)
+                if result is None:
+                    logger.error('⚠️ Не удалось синхронизировать спин с RemnaWave', subscription_id=subscription.id)
+                else:
+                    logger.info('✅ Спин синхронизирован с RemnaWave', subscription_id=subscription.id)
+            except Exception as e:
+                logger.error('⚠️ Ошибка синхронизации спина с RemnaWave', error=e, subscription_id=subscription.id)
+
     async def _process_days_payment(
-        self, db: AsyncSession, user: User, config: WheelConfig, subscription: Subscription | None = None
+        self,
+        db: AsyncSession,
+        user: User,
+        config: WheelConfig,
+        subscription: Subscription | None = None,
+        pending_sync: dict[int, Subscription] | None = None,
     ) -> int:
         """
         Обработать оплату днями подписки.
@@ -360,16 +392,12 @@ class FortuneWheelService:
 
         logger.info('📅 Списано дней подписки у user_id', spin_cost_days=config.spin_cost_days, user_id=user.id)
 
-        # Синхронизируем с RemnaWave
-        try:
-            subscription_service = SubscriptionService()
-            result = await subscription_service.update_remnawave_user(db, subscription)
-            if result is not None:
-                logger.info('✅ Списание дней синхронизировано с RemnaWave для user_id', user_id=user.id)
-            else:
-                logger.error('⚠️ Не удалось синхронизировать списание дней с RemnaWave', user_id=user.id)
-        except Exception as e:
-            logger.error('⚠️ Ошибка синхронизации списания дней с RemnaWave', error=e, user_id=user.id)
+        # В панель отсюда НЕ ходим: приз ещё не начислен, и такой PATCH унёс бы
+        # заведомо устаревший trafficLimitBytes. Между ним и синком приза
+        # успевал сработать крон панели findExceededUsers (*/45 * * * * *) и
+        # поставить LIMITED, который второй PATCH уже не снимал. Синк делает
+        # spin() один раз, когда подписка приведена в финальное состояние.
+        self._defer_panel_sync(pending_sync, subscription)
 
         return kopeks
 
@@ -380,6 +408,7 @@ class FortuneWheelService:
         prize: WheelPrize,
         config: WheelConfig,
         subscription: Subscription | None = None,
+        pending_sync: dict[int, Subscription] | None = None,
     ) -> str | None:
         """
         Применить приз к пользователю.
@@ -471,13 +500,7 @@ class FortuneWheelService:
                     subscription.updated_at = datetime.now(UTC)
                     logger.info('📅 Начислено дней подписки user_id', prize_value=prize.prize_value, user_id=user.id)
 
-                    # Синхронизируем с RemnaWave
-                    try:
-                        subscription_service = SubscriptionService()
-                        await subscription_service.update_remnawave_user(db, subscription)
-                        logger.info('✅ Синхронизировано с RemnaWave для user_id', user_id=user.id)
-                    except Exception as e:
-                        logger.error('⚠️ Ошибка синхронизации с RemnaWave', error=e)
+                    self._defer_panel_sync(pending_sync, subscription)
             else:
                 # Если нет подписки - начисляем на баланс эквивалент
                 await add_user_balance(
@@ -516,13 +539,7 @@ class FortuneWheelService:
                 subscription.updated_at = datetime.now(UTC)
                 logger.info('📊 Начислено трафика user_id', prize_value=prize.prize_value, user_id=user.id)
 
-                # Синхронизируем с RemnaWave
-                try:
-                    subscription_service = SubscriptionService()
-                    await subscription_service.update_remnawave_user(db, subscription)
-                    logger.info('✅ Трафик синхронизирован с RemnaWave для user_id', user_id=user.id)
-                except Exception as e:
-                    logger.error('⚠️ Ошибка синхронизации трафика с RemnaWave', error=e)
+                self._defer_panel_sync(pending_sync, subscription)
             else:
                 # Если безлимит или нет подписки - на баланс
                 await add_user_balance(
@@ -655,6 +672,11 @@ class FortuneWheelService:
                     message='Выберите подписку для оплаты днями',
                 )
 
+            # Подписки, которые спин изменил: в панель уходит ОДИН PATCH на каждую
+            # и только после начисления приза. Два PATCH подряд оставляли окно
+            # для крона панели findExceededUsers — см. _defer_panel_sync.
+            pending_sync: dict[int, Subscription] = {}
+
             # 2. Обрабатываем оплату
             if payment_type == WheelSpinPaymentType.TELEGRAM_STARS.value:
                 if not availability.can_pay_stars:
@@ -673,7 +695,9 @@ class FortuneWheelService:
                         message='Оплата днями подписки недоступна',
                     )
                 payment_amount = config.spin_cost_days
-                payment_value_kopeks = await self._process_days_payment(db, user, config, target_subscription)
+                payment_value_kopeks = await self._process_days_payment(
+                    db, user, config, target_subscription, pending_sync=pending_sync
+                )
             else:
                 return SpinResult(
                     success=False,
@@ -689,7 +713,13 @@ class FortuneWheelService:
             rotation = self._calculate_rotation(prizes, selected_prize)
 
             # 5. Применяем приз
-            generated_promocode = await self._apply_prize(db, user, selected_prize, config, target_subscription)
+            generated_promocode = await self._apply_prize(
+                db, user, selected_prize, config, target_subscription, pending_sync=pending_sync
+            )
+
+            # Единственный поход в панель за спин — уже с финальным состоянием
+            # подписки (списанные дни + начисленный приз).
+            await self._flush_panel_sync(db, pending_sync)
             promocode_id = None
             if generated_promocode:
                 # Получаем ID промокода

--- a/tests/services/test_stale_limited_recovery.py
+++ b/tests/services/test_stale_limited_recovery.py
@@ -1,0 +1,142 @@
+"""Страховка от залипшего LIMITED после апдейта панели.
+
+Крон панели ``findExceededUsers`` (``*/45 * * * * *``) ставит LIMITED всем, у кого
+``status=ACTIVE AND usedTraffic >= trafficLimit``. Если он успевает сработать между
+чтением и записью нашего PATCH, юзер остаётся LIMITED уже с ПОДНЯТЫМ лимитом:
+``users.service.ts::updateUser`` снимает статус только когда до записи юзер был не
+ACTIVE, либо был LIMITED и лимит вырос. В окне гонки не выполняется ни то, ни другое,
+а обратного пересчёта «used < limit ⇒ снять LIMITED» в панели нет ни в одном кроне.
+
+Один PATCH на операцию сужает окно, но не закрывает его: крон может встать между
+чтением и записью самого этого PATCH. Поэтому по ответу панели проверяем статус и
+дожимаем ``POST /api/users/{id}/actions/enable``, когда лимит уже больше
+израсходованного. Лечит гонку для всех повышений лимита, а не только для колеса.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.external.remnawave_api import UserStatus
+from app.services.subscription_service import SubscriptionService
+
+
+def _panel_user(status: UserStatus, limit_bytes: int, used_bytes: int | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1620,
+        status=status,
+        traffic_limit_bytes=limit_bytes,
+        user_traffic=None if used_bytes is None else SimpleNamespace(used_traffic_bytes=used_bytes),
+    )
+
+
+GB = 1024**3
+
+
+def _api(enabled_user=None) -> AsyncMock:
+    api = AsyncMock()
+    api.enable_user = AsyncMock(return_value=enabled_user)
+    api.get_user_by_id = AsyncMock(return_value=None)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_enables_when_limit_now_exceeds_used() -> None:
+    """Реальный кейс: лимит поднят до 410 ГиБ, израсходовано 400.07 — LIMITED залип."""
+    svc = SubscriptionService()
+    limited = _panel_user(UserStatus.LIMITED, 410 * GB, int(400.07 * GB))
+    active = _panel_user(UserStatus.ACTIVE, 410 * GB, int(400.07 * GB))
+    api = _api(enabled_user=active)
+
+    result = await svc._clear_stale_limited_status(api, 1620, limited, intended_active=True)
+
+    api.enable_user.assert_awaited_once_with(1620)
+    assert result.status == UserStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_enables_when_limit_is_unlimited() -> None:
+    svc = SubscriptionService()
+    limited = _panel_user(UserStatus.LIMITED, 0, 500 * GB)
+    api = _api(enabled_user=_panel_user(UserStatus.ACTIVE, 0, 500 * GB))
+
+    await svc._clear_stale_limited_status(api, 1620, limited, intended_active=True)
+
+    api.enable_user.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_leaves_genuinely_exceeded_user_limited() -> None:
+    """Трафик реально исчерпан — LIMITED заслуженный, снимать его нельзя."""
+    svc = SubscriptionService()
+    limited = _panel_user(UserStatus.LIMITED, 400 * GB, int(400.07 * GB))
+    api = _api()
+
+    result = await svc._clear_stale_limited_status(api, 1620, limited, intended_active=True)
+
+    api.enable_user.assert_not_awaited()
+    assert result.status == UserStatus.LIMITED
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_limited_statuses() -> None:
+    svc = SubscriptionService()
+    for status in (UserStatus.ACTIVE, UserStatus.DISABLED, UserStatus.EXPIRED):
+        api = _api()
+        await svc._clear_stale_limited_status(api, 1620, _panel_user(status, 410 * GB, 1 * GB), intended_active=True)
+        api.enable_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_does_nothing_when_we_did_not_intend_active() -> None:
+    """Подписка истекла — мы сами отправили DISABLED, снимать статус не наше дело."""
+    svc = SubscriptionService()
+    api = _api()
+
+    await svc._clear_stale_limited_status(
+        api, 1620, _panel_user(UserStatus.LIMITED, 410 * GB, 1 * GB), intended_active=False
+    )
+
+    api.enable_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_asks_panel_for_used_traffic_when_response_omits_it() -> None:
+    """Ответ на PATCH может не содержать userTraffic — тогда спрашиваем отдельно."""
+    svc = SubscriptionService()
+    limited = _panel_user(UserStatus.LIMITED, 410 * GB, None)
+    api = _api(enabled_user=_panel_user(UserStatus.ACTIVE, 410 * GB, int(400.07 * GB)))
+    api.get_user_by_id = AsyncMock(return_value=_panel_user(UserStatus.LIMITED, 410 * GB, int(400.07 * GB)))
+
+    await svc._clear_stale_limited_status(api, 1620, limited, intended_active=True)
+
+    api.get_user_by_id.assert_awaited_once_with(1620)
+    api.enable_user.assert_awaited_once_with(1620)
+
+
+@pytest.mark.asyncio
+async def test_stays_put_when_used_traffic_is_unknowable() -> None:
+    """Расход выяснить не удалось — не трогаем: воскресить исчерпавшего хуже."""
+    svc = SubscriptionService()
+    limited = _panel_user(UserStatus.LIMITED, 410 * GB, None)
+    api = _api()
+
+    await svc._clear_stale_limited_status(api, 1620, limited, intended_active=True)
+
+    api.enable_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enable_failure_does_not_break_the_caller() -> None:
+    """Приз уже начислен и закоммичен — падать на страховке нельзя."""
+    svc = SubscriptionService()
+    limited = _panel_user(UserStatus.LIMITED, 410 * GB, int(400.07 * GB))
+    api = _api()
+    api.enable_user = AsyncMock(side_effect=RuntimeError('panel down'))
+
+    result = await svc._clear_stale_limited_status(api, 1620, limited, intended_active=True)
+
+    assert result is limited

--- a/tests/test_wheel_panel_sync_race.py
+++ b/tests/test_wheel_panel_sync_race.py
@@ -1,0 +1,172 @@
+"""Спин колеса не должен оставлять юзера LIMITED в панели (прод-репорт 27.08.2026).
+
+Один спин с оплатой днями ходил в панель ДВАЖДЫ: сначала синк списания дней
+(``_process_days_payment``), потом синк приза (``_apply_prize``). Первый PATCH
+уносил ``status=ACTIVE`` со СТАРЫМ ``trafficLimitBytes`` — призовой трафик ещё не
+начислен. Крон панели ``findExceededUsers`` крутится по ``*/45 * * * * *``, то есть
+бьёт в :00 и :45 каждой минуты, и между двумя PATCH успевал поставить LIMITED
+(``used >= limit``).
+
+Второй PATCH это уже не чинил: ``users.service.ts::updateUser`` снимает статус
+только если ``user.status !== 'ACTIVE' && dto.status === 'ACTIVE'`` либо
+``user.status === 'LIMITED' && trafficLimitBytes > user.trafficLimitBytes``. PATCH #2
+прочитал юзера ещё как ACTIVE (крон закоммитился в том же окне) — мимо обеих
+веток, записался только лимит. Обратного пересчёта «used < limit ⇒ снять LIMITED»
+в панели нет, поэтому состояние залипало навсегда: VPN не работал, лечилось
+только руками.
+
+Реальный кейс: панель id 1620, лимит 400 → 410 ГиБ, used 400.07 ГиБ,
+спин 18:02:59–18:03:00 MSK.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.config import settings
+from app.services.wheel_service import FortuneWheelService, SpinAvailability
+
+
+def _subscription() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=10,
+        user_id=1,
+        is_active=True,
+        days_left=90,
+        end_date=datetime.now(UTC) + timedelta(days=90),
+        updated_at=datetime.now(UTC),
+        traffic_limit_gb=400,
+        status='active',
+    )
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        spin_cost_days=1,
+        min_subscription_days_for_day_payment=1,
+        daily_spin_limit=5,
+        spin_cost_stars=10,
+        spin_cost_stars_enabled=True,
+        spin_cost_days_enabled=True,
+    )
+
+
+class _SyncSpy:
+    """Пишет состояние подписки на КАЖДЫЙ поход в панель."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def __call__(self, db, subscription, **kwargs):
+        self.calls.append(
+            {
+                'traffic_limit_gb': subscription.traffic_limit_gb,
+                'end_date': subscription.end_date,
+            }
+        )
+        return SimpleNamespace(status=None)
+
+
+async def _run_spin(prize: SimpleNamespace, subscription: SimpleNamespace, spy: _SyncSpy) -> None:
+    """Прогнать настоящий spin() с оплатой днями — контракт держится на нём.
+
+    Проверять сами хелперы бесполезно: пропущенный flush в spin() такой тест не
+    заметил бы, а именно он и превращает отложенный синк в «в панель не ушло
+    ничего».
+    """
+    svc = FortuneWheelService()
+    user = SimpleNamespace(id=1, balance_kopeks=0)
+    config = _config()
+
+    with ExitStack() as s:
+        service_cls = MagicMock()
+        service_cls.return_value = SimpleNamespace(update_remnawave_user=spy)
+        s.enter_context(patch('app.services.wheel_service.SubscriptionService', service_cls))
+        s.enter_context(patch.object(type(settings), 'is_multi_tariff_enabled', lambda self: False))
+        s.enter_context(patch('app.services.wheel_service.add_user_balance', AsyncMock()))
+        s.enter_context(
+            patch.object(
+                svc,
+                'check_availability',
+                AsyncMock(return_value=SpinAvailability(can_spin=True, can_pay_days=True)),
+            )
+        )
+        s.enter_context(patch('app.services.wheel_service.get_or_create_wheel_config', AsyncMock(return_value=config)))
+        s.enter_context(patch('app.services.wheel_service.get_wheel_prizes', AsyncMock(return_value=[prize])))
+        s.enter_context(patch('app.database.crud.user.lock_user_for_update', AsyncMock(return_value=user)))
+        s.enter_context(patch('app.services.wheel_service.get_user_spins_today', AsyncMock(return_value=0)))
+        s.enter_context(
+            patch('app.services.wheel_service.get_subscription_by_user_id', AsyncMock(return_value=subscription))
+        )
+        s.enter_context(patch.object(svc, 'calculate_prize_probabilities', lambda *a, **kw: [(prize, 100.0)]))
+        s.enter_context(patch.object(svc, '_select_prize', lambda prizes_with_probs: prize))
+        s.enter_context(patch.object(svc, '_calculate_rotation', lambda prizes, selected: 0))
+        s.enter_context(patch('app.services.wheel_service.create_wheel_spin', AsyncMock()))
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(fetchone=lambda: None))
+        result = await svc.spin(db, user, 'subscription_days')
+
+    assert result.success is True, f'спин не прошёл: {result.error} / {result.message}'
+
+
+@pytest.mark.asyncio
+async def test_days_paid_traffic_prize_syncs_panel_once_with_final_state() -> None:
+    subscription = _subscription()
+    original_end = subscription.end_date
+    spy = _SyncSpy()
+    prize = SimpleNamespace(
+        id=7,
+        prize_type='traffic_gb',
+        prize_value=10,
+        prize_value_kopeks=1000,
+        display_name='+10 ГБ',
+        emoji='📊',
+        color='#fff',
+        probability=100,
+        is_active=True,
+    )
+
+    await _run_spin(prize, subscription, spy)
+
+    assert len(spy.calls) == 1, (
+        f'панель должна обновляться один раз за спин, было {len(spy.calls)}: '
+        'первый PATCH со старым лимитом и есть окно для крона findExceededUsers'
+    )
+    call = spy.calls[0]
+    assert call['traffic_limit_gb'] == 410, 'в панель должен уехать уже начисленный лимит'
+    assert call['end_date'] < original_end, 'и уже списанные дни'
+
+
+@pytest.mark.asyncio
+async def test_days_paid_non_subscription_prize_still_syncs_charge() -> None:
+    """Приз мимо подписки (баланс) — списание дней всё равно обязано доехать до панели.
+
+    Просто убрать синк из списания мало: с призом, который подписку не трогает,
+    в панель не ушло бы ничего, и юзер сохранил бы старый срок, заплатив днями.
+    """
+    subscription = _subscription()
+    original_end = subscription.end_date
+    spy = _SyncSpy()
+    prize = SimpleNamespace(
+        id=8,
+        prize_type='balance',
+        prize_value=100,
+        prize_value_kopeks=10000,
+        display_name='100 ₽',
+        emoji='💰',
+        color='#fff',
+        probability=100,
+        is_active=True,
+    )
+
+    await _run_spin(prize, subscription, spy)
+
+    assert len(spy.calls) == 1, 'списание дней обязано доехать до панели даже с призом мимо подписки'
+    assert spy.calls[0]['end_date'] < original_end


### PR DESCRIPTION
Закрывает баг-репорт: приз «+N ГБ трафика» оставляет юзера в статусе LIMITED в панели.

## Проверка репорта

Прошёлся по коду — всё описанное подтвердилось (номера строк уехали, версия в репорте 4.0.0):

* `_process_days_payment` синкает панель на `wheel_service.py:366` — **до** начисления приза;
* `_apply_prize` синкает ещё раз (ветки `SUBSCRIPTION_DAYS` и `TRAFFIC_GB`);
* в `spin()` первое идёт шагом 2, второе — шагом 5, то есть два PATCH подряд гарантированы;
* `update_remnawave_user` действительно возвращает `RemnaWaveUser` со `status` и `traffic_limit_bytes`, а `user_traffic.used_traffic_bytes` даёт расход;
* `RemnaWaveAPI.enable_user` на месте.

Диагноз в репорте точный, включая то, почему второй PATCH не спасает: `users.service.ts::updateUser` снимает статус только когда до записи юзер был не ACTIVE либо был LIMITED и лимит вырос. В окне гонки не выполняется ни то, ни другое — записывается только `trafficLimitBytes`, а обратного пересчёта «used < limit ⇒ снять LIMITED» в панели нет ни в одном кроне. Отсюда «залипает навсегда».

## Что сделано

**1. Один PATCH на спин.** `spin()` собирает затронутые подписки в `pending_sync`, а `_process_days_payment` и `_apply_prize` только помечают их. Единственный `update_remnawave_user` уходит после того, как подписка приведена в финальное состояние — со списанными днями и начисленным призом.

Важная деталь, из-за которой нельзя просто убрать синк из списания: если приз подписку не трогает (баланс, промокод), синка не было бы вовсе — юзер заплатил бы днями, а в панели остался бы старый срок. Поэтому именно отложенный синк, а не удалённый; на это есть отдельный тест.

**2. Страховка на LIMITED — в `update_remnawave_user`, а не в колесе.** Один PATCH сужает окно, но не закрывает: крон может встать между чтением и записью самого этого PATCH. По ответу панели проверяем статус и дожимаем `POST /api/users/{id}/actions/enable`. Раз это в общем пути синка, оно закрывает гонку сразу для всех повышений лимита — колесо, докупка трафика (`traffic.py`, `purchase.py`, `miniapp.py`), смена тарифа, — то есть п.3 репорта тоже.

Страховка сознательно консервативна, воскресить реально исчерпавшего трафик хуже, чем оставить как есть:

* `enable` дожимается, только когда доказано `used < limit`;
* если `userTraffic` в ответе на PATCH нет — один `get_user_by_id`, и при неудаче ничего не трогаем;
* безлимит (`limit == 0`) — основание всегда: LIMITED при нём бессмысленен;
* `intended_active=False` (мы сами слали DISABLED) — не наше дело;
* сбой `enable` не роняет вызывающий код: к этому моменту приз уже начислен и закоммичен.

## Тесты

* `tests/test_wheel_panel_sync_race.py` — гоняет **настоящий `spin()`**: один синк за спин и в нём уже финальное состояние (лимит 410, списанные дни); отдельно — что приз мимо подписки списание всё равно доносит. Через хелперы проверять было бы бесполезно: пропущенный flush такой тест не заметил бы.
* `tests/services/test_stale_limited_recovery.py` — 8 случаев решения: реальный кейс (410 ГиБ / 400.07 использовано), безлимит, честно исчерпанный трафик, не-LIMITED статусы, `intended_active=False`, дозапрос расхода, неизвестный расход, падение `enable`.

**9 из 10 падают на `dev`.**

## Проверки

`pytest` — **5105 passed, 6 skipped**. `ruff check` и `ruff format --check` чистые.

## Чего не делал

Ручного лечения уже залипших юзеров тут нет — фикс останавливает появление новых. Для 1620 и подобных достаточно одного `POST /api/users/{id}/actions/enable`; если нужно, добавлю разовый прогон по LIMITED-юзерам с `used < limit` отдельным PR.