### PR TITLE
feat(channel): флаг CHANNEL_REQUIRED_FOR_PAID — не требовать подписку на канал от платящих

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -162,6 +162,7 @@ class Settings(BaseSettings):
     CHANNEL_IS_REQUIRED_SUB: bool = False
     CHANNEL_DISABLE_TRIAL_ON_UNSUBSCRIBE: bool = True
     CHANNEL_REQUIRED_FOR_ALL: bool = False
+    CHANNEL_REQUIRED_FOR_PAID: bool = True
 
     DATABASE_URL: str | None = None
 

--- a/app/middlewares/channel_checker.py
+++ b/app/middlewares/channel_checker.py
@@ -155,6 +155,10 @@ class ChannelCheckerMiddleware(BaseMiddleware):
         if is_registration_process(event, current_state):
             return await handler(event, data)
 
+        # Подписка на канал — антифрод против фермы триалов; платящему она не нужна.
+        if not settings.CHANNEL_REQUIRED_FOR_PAID and await self._has_active_paid_subscription(telegram_id):
+            return await handler(event, data)
+
         # Ensure service has bot reference for API fallback
         bot: Bot = data['bot']
         if not channel_subscription_service.bot:
@@ -489,6 +493,14 @@ class ChannelCheckerMiddleware(BaseMiddleware):
                 await db.rollback()
 
     # -- _deactivate (multi-channel) -------------------------------------------
+
+    @staticmethod
+    async def _has_active_paid_subscription(telegram_id: int) -> bool:
+        """Есть ли у пользователя активная НЕтриальная подписка."""
+        async with AsyncSessionLocal() as db:
+            user = await get_user_by_telegram_id(db, telegram_id)
+            subs = getattr(user, 'subscriptions', None) or []
+            return any(s.status == SubscriptionStatus.ACTIVE.value and not s.is_trial for s in subs)
 
     async def _deactivate_subscription_on_unsubscribe(
         self,

--- a/docs/project_structure_reference.md
+++ b/docs/project_structure_reference.md
@@ -1283,7 +1283,7 @@
   Классы: `ButtonStatsMiddleware` (6 методов)
   Функции: нет
 - `app/middlewares/channel_checker.py` — Python-модуль
-  Классы: `ChannelCheckerMiddleware` (8 методов)
+  Классы: `ChannelCheckerMiddleware` (9 методов)
   Функции: `save_pending_payload_to_redis` — Save pending_start_payload to Redis via the shared cache singleton., `get_pending_payload_from_redis` — Get pending_start_payload from Redis via the shared cache singleton., `delete_pending_payload_from_redis` — Delete pending_start_payload from Redis via the shared cache singleton.
 - `app/middlewares/chat_type_filter.py` — Python-модуль
   Классы: `ChatTypeFilterMiddleware` (1 методов)


### PR DESCRIPTION
Closes #3202.


**Что меняется**
- `app/config.py`: новый флаг `CHANNEL_REQUIRED_FOR_PAID: bool = True`. Дефолт сохраняет текущее поведение — у существующих инсталляций ничего не меняется.
- `app/middlewares/channel_checker.py`: при `CHANNEL_REQUIRED_FOR_PAID=false` пользователь с активной нетриальной подпиской проходит дальше сразу после исключений admin/moderator/registration. Проверка стоит **до** обращения к `channel_subscription_service`, поэтому для платящих не тратится ни запрос к Telegram API, ни кэш.
- Хелпер `_has_active_paid_subscription` использует уже импортированные в файле `AsyncSessionLocal`, `get_user_by_telegram_id` и `SubscriptionStatus` — новых зависимостей нет.

**Чего НЕ меняется**
- Триальный гейт, `CHANNEL_DISABLE_TRIAL_ON_UNSUBSCRIBE`, `CHANNEL_REQUIRED_FOR_ALL`, деактивация и реактивация при отписке/подписке — ни строкой.

**Как проверено**
Боевой инстанс v4.2.0, 33 активные подписки. После выкатки прогнан хелпер на реальных telegram_id: два пользователя с активной платной подпиской и без подписки на канал → `True` (проходят), активный триальщик → `False` (упирается в гейт, как и должен). Ошибок в логах на старте нет, вебхук не пострадал.

Тесты и строку в документацию добавлю, если скажете, в каком виде это удобнее.
