### PR TITLE
fix(rich-menu): cache-busting для URL логотипа в rich-меню

### DIFF
--- a/app/utils/rich_menu.py
+++ b/app/utils/rich_menu.py
@@ -159,7 +159,17 @@ def _resolve_rich_logo_url() -> str:
     parsed = urlparse(webhook_url)
     if not parsed.scheme or not parsed.netloc:
         return ''
-    return f'{parsed.scheme}://{parsed.netloc}/cabinet/branding/bot-logo'
+    # Cache-busting: Telegram скачивает медиа по URL один раз и дальше кеширует
+    # результат за этим URL бессрочно, независимо от Cache-Control сервера —
+    # без версии в query при замене LOGO_FILE на диске rich-меню годами
+    # показывало бы старый кадр. Версия — mtime файла, растёт при каждой
+    # реальной замене и не меняется, пока файл не тронут (не дёргает Telegram
+    # на каждый рендер меню).
+    try:
+        version = int(Path(settings.LOGO_FILE).stat().st_mtime)
+    except OSError:
+        version = 0
+    return f'{parsed.scheme}://{parsed.netloc}/cabinet/branding/bot-logo?v={version}'
 
 
 def _is_media_fetch_error(error: Exception) -> bool:


### PR DESCRIPTION
## Проблема

`_resolve_rich_logo_url()` в `app/utils/rich_menu.py` строит статичный URL
логотипа `{WEBHOOK_URL}/cabinet/branding/bot-logo` без какого-либо
версионирования.

Telegram скачивает медиа, переданное по URL в rich-сообщении, один раз и
кеширует результат на своей стороне за этим URL — бессрочно, независимо
от `Cache-Control` в ответе сервера. Если администратор меняет `LOGO_FILE`
на диске после того, как rich-меню хотя бы раз отправлялось пользователям
(что при боевой эксплуатации бота — обычное дело: ребрендинг, смена
логотипа), rich-меню продолжает показывать старую картинку неограниченно
долго, потому что URL логотипа не изменился и Telegram не видит повода
перескачивать файл.

При этом остальные пути отправки логотипа (`get_logo_media()` — прямая
загрузка файла с кэшем `file_id` на процесс) корректно подхватывают новый
файл при первой отправке после рестарта, что и делает расхождение
особенно заметным: один и тот же логотип выглядит по-разному в
классическом меню/колбэках и в rich-шапке.

## Фикс

Добавлена версия в query-параметр URL на основе `mtime` файла `LOGO_FILE`.
Пока файл не менялся — URL стабилен, лишних скачиваний на каждый рендер
меню не будет. При реальной замене файла `mtime` меняется, URL становится
новым, и Telegram скачивает актуальную картинку.

## Проверено

Воспроизведено и проверено на боевом инстансе: до фикса rich-меню
показывало логотип, отличный от актуального `LOGO_FILE`, при этом прямая
проверка эндпоинта (`curl`) подтверждала, что сервер отдаёт корректный
файл — расхождение было именно в кэшировании на стороне Telegram. После
добавления `?v={mtime}` и замены логотипа — rich-меню обновилось на
следующий рендер без необходимости менять что-либо ещё.