### PR TITLE
fix(payments): share post-deposit side effects for manual/admin credits

### DIFF
--- a/app/services/deposit_side_effects.py
+++ b/app/services/deposit_side_effects.py
@@ -1,0 +1,97 @@
+"""Shared post-deposit pipeline for every successful balance credit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import User
+
+
+logger = structlog.get_logger(__name__)
+
+
+async def after_successful_deposit(
+    db: AsyncSession,
+    user: User,
+    amount_kopeks: int,
+    *,
+    bot: Any | None = None,
+    was_first_topup: bool,
+    apply_bonuses: bool = True,
+    notify_email: bool = True,
+) -> None:
+    """Run referral + first-topup flag + cart/auto-extend after money is committed.
+
+    Never raises: the credit itself already succeeded; callers must not retry it
+    because of a side-effect failure.
+
+    Transaction contract:
+    - This helper does **not** call ``db.commit()`` or ``db.rollback()``.
+    - It may mutate ``user.has_made_first_topup`` in memory (and refresh ``user``).
+    - ``process_referral_topup`` may still commit on its own (existing behaviour).
+    - The caller must ``await db.commit()`` after this returns if they need the
+      first-topup flag (and any other in-session mutations) persisted, especially
+      when invoking from an already-open transaction.
+    """
+    if not apply_bonuses or amount_kopeks <= 0:
+        return
+
+    try:
+        await _apply_referral_and_first_topup(
+            db, user, amount_kopeks, was_first_topup=was_first_topup, bot=bot
+        )
+    except Exception as error:
+        logger.error(
+            'Post-deposit referral failed',
+            user_id=getattr(user, 'id', None),
+            amount_kopeks=amount_kopeks,
+            error=error,
+            exc_info=True,
+        )
+
+    try:
+        from app.services.payment.common import send_cart_notification_after_topup
+
+        await send_cart_notification_after_topup(
+            user, amount_kopeks, db, bot, notify_email=notify_email
+        )
+    except Exception as error:
+        logger.error(
+            'Post-deposit autopay/cart failed',
+            user_id=getattr(user, 'id', None),
+            amount_kopeks=amount_kopeks,
+            error=error,
+            exc_info=True,
+        )
+
+
+async def _apply_referral_and_first_topup(
+    db: AsyncSession,
+    user: User,
+    amount_kopeks: int,
+    *,
+    was_first_topup: bool,
+    bot: Any | None,
+) -> None:
+    try:
+        from app.services.referral_service import process_referral_topup
+
+        await process_referral_topup(db, user.id, amount_kopeks, bot)
+    except Exception as error:
+        logger.error(
+            'process_referral_topup failed',
+            user_id=user.id,
+            amount_kopeks=amount_kopeks,
+            error=error,
+            exc_info=True,
+        )
+
+    await db.refresh(user)
+    # Referrals: flag is set inside process_referral_topup when deferred bonus pays out.
+    # Non-referrals still need the flag for first-topup stats/thresholds.
+    # Caller owns commit — see after_successful_deposit docstring.
+    if was_first_topup and not user.has_made_first_topup and not user.referred_by_id:
+        user.has_made_first_topup = True

--- a/app/services/manual_topup_service.py
+++ b/app/services/manual_topup_service.py
@@ -211,20 +211,24 @@ async def credit_manual_topup(
             description=description,
         )
 
-        if apply_topup_bonuses:
-            await _apply_referral_topup(db, locked, amount_kopeks, was_first_topup=was_first_topup, bot=bot)
-
         await _notify_admins(db, locked, transaction, old_balance, bot=bot)
 
         if notify_user:
             await _notify_user(locked, amount_kopeks, transaction, bot=bot)
 
         if apply_topup_bonuses:
-            from app.services.payment.common import send_cart_notification_after_topup
+            from app.services.deposit_side_effects import after_successful_deposit
 
-            # notify_email=False — письмо для юзеров без Telegram уже ушло из
-            # _notify_user, под общим гейтом notify_user.
-            await send_cart_notification_after_topup(locked, amount_kopeks, db, bot, notify_email=False)
+            await after_successful_deposit(
+                db,
+                locked,
+                amount_kopeks,
+                bot=bot,
+                was_first_topup=was_first_topup,
+                notify_email=False,
+            )
+            await db.commit()
+            await db.refresh(locked)
     except Exception as error:
         logger.error(
             'Ошибка пост-обработки ручного пополнения (деньги зачислены)',
@@ -240,34 +244,6 @@ async def credit_manual_topup(
         new_balance_kopeks=new_balance,
         duplicate=False,
     )
-
-
-async def _apply_referral_topup(
-    db: AsyncSession,
-    user: User,
-    amount_kopeks: int,
-    *,
-    was_first_topup: bool,
-    bot: Bot | None,
-) -> None:
-    try:
-        from app.services.referral_service import process_referral_topup
-
-        await process_referral_topup(db, user.id, amount_kopeks, bot)
-    except Exception as error:
-        logger.error('Ошибка реферальной обработки ручного пополнения', user_id=user.id, error=error)
-
-    # Для рефералов флаг «первое пополнение» выставляет сам process_referral_topup —
-    # там он завязан на выдачу отложенного бонуса. Здесь добираем только тех, у кого
-    # реферера нет: иначе бонус реферера остался бы невыданным навсегда.
-    if was_first_topup and not user.has_made_first_topup and not user.referred_by_id:
-        try:
-            user.has_made_first_topup = True
-            await db.commit()
-            await db.refresh(user)
-        except Exception as error:
-            await db.rollback()
-            logger.error('Не удалось отметить первое пополнение', user_id=user.id, error=error)
 
 
 async def _notify_admins(

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -539,6 +539,7 @@ class UserService:
             # Сохраняем старый баланс для уведомления
 
             if amount_kopeks > 0:
+                was_first_topup = not user.has_made_first_topup
                 await add_user_balance(
                     db, user, amount_kopeks, description=description, payment_method=PaymentMethod.MANUAL
                 )
@@ -549,6 +550,26 @@ class UserService:
                     amount_kopeks=amount_kopeks / 100,
                 )
                 success = True
+                try:
+                    from app.services.deposit_side_effects import after_successful_deposit
+
+                    await after_successful_deposit(
+                        db,
+                        user,
+                        amount_kopeks,
+                        bot=bot,
+                        was_first_topup=was_first_topup,
+                    )
+                    await db.commit()
+                    await db.refresh(user)
+                except Exception as side_error:
+                    logger.error(
+                        'Ошибка пост-обработки после пополнения админом',
+                        user_id=user.id,
+                        amount_kopeks=amount_kopeks,
+                        error=side_error,
+                        exc_info=True,
+                    )
             else:
                 success = await subtract_user_balance(
                     db,


### PR DESCRIPTION
## Summary
Gateway webhooks already run referral + first-topup flag + saved-cart / auto-extend after a successful balance credit. Some **manual/admin** credit paths only change the balance and skip that pipeline.

That is one root cause with two symptoms:
1. referrers get no commission / `has_made_first_topup` stays wrong;
2. expired subscription / saved cart is not auto-renewed even though the balance is enough.

## Solution
Add a shared `after_successful_deposit(...)` helper and call it from:
- `credit_manual_topup` (replaces private `_apply_referral_topup` + direct cart call)
- admin `UserService.update_user_balance` on positive credits

Provider-specific Telegram copy stays at the call site.

### Transaction contract
`after_successful_deposit` does **not** call `db.commit()` / `db.rollback()`. It may mutate `user.has_made_first_topup` in memory; the **caller** commits afterward (see call sites). This keeps the helper safe inside an already-open transaction. (`process_referral_topup` may still commit on its own — existing behaviour.)

## Question for maintainers
Should gateway webhook handlers also be migrated onto `after_successful_deposit` in a follow-up, or do you prefer to leave provider paths as they are for now?

## Test plan
- [ ] Admin credits a referred user who never topped up → referral runs; first-topup flag set for non-referrals
- [ ] Admin credits a user with saved cart / expired auto-extend eligible sub → same autopay path as after a gateway top-up
- [ ] `credit_manual_topup(..., apply_topup_bonuses=False)` still skips bonuses
- [ ] Existing gateway webhook top-ups unchanged


Made with [Cursor](https://cursor.com)