### PR TITLE
fix(wheel): приз доезжает до пользователя целиком + промогруппа как приз

### DIFF
--- a/app/cabinet/routes/admin_wheel.py
+++ b/app/cabinet/routes/admin_wheel.py
@@ -65,6 +65,7 @@ async def get_admin_wheel_config(
             promo_balance_bonus_kopeks=p.promo_balance_bonus_kopeks or 0,
             promo_subscription_days=p.promo_subscription_days or 0,
             promo_traffic_gb=p.promo_traffic_gb or 0,
+            promo_group_id=p.promo_group_id,
             created_at=p.created_at,
             updated_at=p.updated_at,
         )
@@ -128,6 +129,7 @@ async def update_admin_wheel_config(
             promo_balance_bonus_kopeks=p.promo_balance_bonus_kopeks or 0,
             promo_subscription_days=p.promo_subscription_days or 0,
             promo_traffic_gb=p.promo_traffic_gb or 0,
+            promo_group_id=p.promo_group_id,
             created_at=p.created_at,
             updated_at=p.updated_at,
         )
@@ -178,6 +180,7 @@ async def get_prizes(
             promo_balance_bonus_kopeks=p.promo_balance_bonus_kopeks or 0,
             promo_subscription_days=p.promo_subscription_days or 0,
             promo_traffic_gb=p.promo_traffic_gb or 0,
+            promo_group_id=p.promo_group_id,
             created_at=p.created_at,
             updated_at=p.updated_at,
         )
@@ -209,6 +212,7 @@ async def create_prize(
         promo_balance_bonus_kopeks=request.promo_balance_bonus_kopeks,
         promo_subscription_days=request.promo_subscription_days,
         promo_traffic_gb=request.promo_traffic_gb,
+        promo_group_id=request.promo_group_id,
     )
 
     logger.info('🎁 Admin created prize', telegram_id=admin.telegram_id, display_name=prize.display_name)
@@ -228,6 +232,7 @@ async def create_prize(
         promo_balance_bonus_kopeks=prize.promo_balance_bonus_kopeks or 0,
         promo_subscription_days=prize.promo_subscription_days or 0,
         promo_traffic_gb=prize.promo_traffic_gb or 0,
+        promo_group_id=prize.promo_group_id,
         created_at=prize.created_at,
         updated_at=prize.updated_at,
     )
@@ -278,6 +283,7 @@ async def update_prize(
         promo_balance_bonus_kopeks=prize.promo_balance_bonus_kopeks or 0,
         promo_subscription_days=prize.promo_subscription_days or 0,
         promo_traffic_gb=prize.promo_traffic_gb or 0,
+        promo_group_id=prize.promo_group_id,
         created_at=prize.created_at,
         updated_at=prize.updated_at,
     )

--- a/app/cabinet/schemas/wheel.py
+++ b/app/cabinet/schemas/wheel.py
@@ -154,6 +154,7 @@ class WheelPrizeAdminResponse(BaseModel):
     promo_balance_bonus_kopeks: int = 0
     promo_subscription_days: int = 0
     promo_traffic_gb: int = 0
+    promo_group_id: int | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -215,6 +216,7 @@ class CreatePrizeRequest(BaseModel):
     promo_balance_bonus_kopeks: int = Field(default=0, ge=0)
     promo_subscription_days: int = Field(default=0, ge=0)
     promo_traffic_gb: int = Field(default=0, ge=0)
+    promo_group_id: int | None = Field(None, ge=1)
 
 
 class UpdatePrizeRequest(BaseModel):
@@ -232,6 +234,7 @@ class UpdatePrizeRequest(BaseModel):
     promo_balance_bonus_kopeks: int | None = Field(None, ge=0)
     promo_subscription_days: int | None = Field(None, ge=0)
     promo_traffic_gb: int | None = Field(None, ge=0)
+    promo_group_id: int | None = Field(None, ge=1)
 
 
 class ReorderPrizesRequest(BaseModel):

--- a/app/database/crud/subscription.py
+++ b/app/database/crud/subscription.py
@@ -1425,7 +1425,9 @@ async def extend_subscription(
     return subscription
 
 
-async def add_subscription_traffic(db: AsyncSession, subscription: Subscription, gb: int) -> Subscription:
+async def add_subscription_traffic(
+    db: AsyncSession, subscription: Subscription, gb: int, commit: bool = True
+) -> Subscription:
     # Lock subscription row — защита от lost-update гонки с housekeeping в extend_subscription
     # (см. _apply_base_limit_preserving_active_purchases / _housekeep_expired_purchases).
     # Без lock'а одновременный renewal + topup могут затереть друг друга.
@@ -1464,8 +1466,11 @@ async def add_subscription_traffic(db: AsyncSession, subscription: Subscription,
         # Первая докупка
         subscription.traffic_reset_at = new_expires_at
 
-    await db.commit()
-    await db.refresh(subscription)
+    # commit=False — для вызова внутри чужой транзакции (спин колеса держит
+    # user-lock и коммитит всё одним куском, как add_user_balance(commit=False)).
+    if commit:
+        await db.commit()
+        await db.refresh(subscription)
 
     logger.info(
         '📈 К подписке пользователя добавлено ГБ трафика (истекает )',
@@ -1480,7 +1485,7 @@ async def add_subscription_traffic(db: AsyncSession, subscription: Subscription,
     # меняется, и хелпер молча выйдет по совпадению сумм.
     from app.services.recurrent_amount import sync_recurrent_bindings_after_price_change
 
-    await sync_recurrent_bindings_after_price_change(db, subscription.id)
+    await sync_recurrent_bindings_after_price_change(db, subscription.id, commit=commit)
 
     return subscription
 

--- a/app/database/crud/wheel.py
+++ b/app/database/crud/wheel.py
@@ -82,7 +82,10 @@ async def get_wheel_prizes(db: AsyncSession, config_id: int = 1, active_only: bo
     if active_only:
         query = query.where(WheelPrize.is_active == True)
 
-    query = query.order_by(WheelPrize.sort_order)
+    # id вторичным ключом сортировки: _calculate_rotation сопоставляет приз
+    # сектору по индексу в этом списке, а при равных sort_order порядок выдачи
+    # БД произволен — стрелка останавливалась не на объявленном призе.
+    query = query.order_by(WheelPrize.sort_order, WheelPrize.id)
 
     result = await db.execute(query)
     return list(result.scalars().all())
@@ -109,6 +112,7 @@ async def create_wheel_prize(
     promo_balance_bonus_kopeks: int = 0,
     promo_subscription_days: int = 0,
     promo_traffic_gb: int = 0,
+    promo_group_id: int | None = None,
 ) -> WheelPrize:
     """Создать новый приз на колесе."""
     prize = WheelPrize(
@@ -125,6 +129,7 @@ async def create_wheel_prize(
         promo_balance_bonus_kopeks=promo_balance_bonus_kopeks,
         promo_subscription_days=promo_subscription_days,
         promo_traffic_gb=promo_traffic_gb,
+        promo_group_id=promo_group_id,
     )
     db.add(prize)
     await db.commit()
@@ -139,9 +144,17 @@ async def update_wheel_prize(db: AsyncSession, prize_id: int, **kwargs) -> Wheel
     if not prize:
         return None
 
+    # promo_group_id обязан уметь сбрасываться в NULL — снять с приза
+    # промогруппу иначе невозможно: общий guard `value is not None` такой
+    # апдейт глотает, и приз навсегда остаётся со скидочной группой.
+    nullable_fields = {'promo_group_id'}
+
     for key, value in kwargs.items():
-        if hasattr(prize, key) and value is not None:
-            setattr(prize, key, value)
+        if not hasattr(prize, key):
+            continue
+        if value is None and key not in nullable_fields:
+            continue
+        setattr(prize, key, value)
 
     prize.updated_at = datetime.now(UTC)
     await db.commit()

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -4355,6 +4355,10 @@ class WheelPrize(Base):
     promo_balance_bonus_kopeks = Column(Integer, default=0)
     promo_subscription_days = Column(Integer, default=0)
     promo_traffic_gb = Column(Integer, default=0)
+    # Промогруппа, в которую попадёт активировавший код. Открывает призы вида
+    # «скидка N% на продление»: назначение промогруппы по промокоду уже умеет
+    # promocode_service, колесу не хватало только способа выдать такой код.
+    promo_group_id = Column(Integer, ForeignKey('promo_groups.id', ondelete='SET NULL'), nullable=True, index=True)
 
     created_at = Column(AwareDateTime(), default=func.now())
     updated_at = Column(AwareDateTime(), default=func.now(), onupdate=func.now())

--- a/app/handlers/stars_payments.py
+++ b/app/handlers/stars_payments.py
@@ -202,7 +202,9 @@ async def _handle_wheel_spin_payment(
         await db.commit()
 
         # Отправляем результат
-        prize_message = wheel_service._get_prize_message(selected_prize, generated_promocode)
+        prize_message = wheel_service._get_prize_message(
+            selected_prize, generated_promocode, validity_days=config.promo_validity_days
+        )
 
         emoji = selected_prize.emoji or '🎁'
         await message.answer(

--- a/app/services/recurrent_amount.py
+++ b/app/services/recurrent_amount.py
@@ -57,11 +57,17 @@ async def resolve_true_renewal_amount(
         return None
 
 
-async def sync_recurrent_bindings_after_price_change(db: AsyncSession, subscription_id: int) -> None:
+async def sync_recurrent_bindings_after_price_change(
+    db: AsyncSession, subscription_id: int, commit: bool = True
+) -> None:
     """Гасит привязки, чья сумма больше не соответствует цене продления.
 
     Вызывается после докупки устройств/трафика. Best-effort: никогда не бросает
     наружу — докупка уже оплачена и не должна падать из-за рекуррента.
+
+    ``commit=False`` — для вызова внутри чужой транзакции: гашение привязки
+    иначе закоммитит её на середине (спин колеса держит user-lock и коммитит
+    всё одним куском).
     """
     try:
         from sqlalchemy import select
@@ -110,12 +116,12 @@ async def sync_recurrent_bindings_after_price_change(db: AsyncSession, subscript
                     cancel_platega_recurring_for_subscription_safe,
                 )
 
-                await cancel_platega_recurring_for_subscription_safe(db, subscription_id)
+                await cancel_platega_recurring_for_subscription_safe(db, subscription_id, commit=commit)
                 agent = _PlategaSbpAgent()
             else:
                 from app.services.payment.lava import _LavaRecurrentAgent, cancel_lava_recurring_for_subscription_safe
 
-                await cancel_lava_recurring_for_subscription_safe(db, subscription_id)
+                await cancel_lava_recurring_for_subscription_safe(db, subscription_id, commit=commit)
                 agent = _LavaRecurrentAgent()
 
             # Уведомление best-effort: у модульного агента нет бота, поэтому

--- a/app/services/wheel_service.py
+++ b/app/services/wheel_service.py
@@ -512,8 +512,14 @@ class FortuneWheelService:
                     return None
                 subscription = await get_subscription_by_user_id(db, user.id)
             if subscription and subscription.traffic_limit_gb > 0:
-                subscription.traffic_limit_gb += prize.prize_value
-                subscription.updated_at = datetime.now(UTC)
+                # Через штатную докупку, а не `traffic_limit_gb += N`: лимит
+                # пересчитывается как base_limit + purchased_gb (см.
+                # _apply_base_limit_preserving_active_purchases), поэтому сырая
+                # прибавка без строки в traffic_purchases стиралась при первом
+                # же продлении или следующей докупке — приз молча исчезал.
+                from app.database.crud.subscription import add_subscription_traffic
+
+                await add_subscription_traffic(db, subscription, prize.prize_value, commit=False)
                 logger.info('📊 Начислено трафика user_id', prize_value=prize.prize_value, user_id=user.id)
 
                 # Синхронизируем с RemnaWave
@@ -550,17 +556,34 @@ class FortuneWheelService:
         # Генерируем уникальный код
         code = f'{config.promo_prefix}{secrets.token_hex(4).upper()}'
 
-        # Определяем тип промокода
-        if prize.promo_subscription_days > 0:
+        days = prize.promo_subscription_days or 0
+        balance = prize.promo_balance_bonus_kopeks or 0
+        traffic = prize.promo_traffic_gb or 0
+
+        # Тип определяет, какие поля промокода вообще применятся при активации
+        # (см. PromoCodeService._apply_promocode_effects). Трафик применяется
+        # ТОЛЬКО у BALANCE_AND_DAYS, поэтому любой набор с гигабайтами обязан
+        # получить именно этот тип — иначе трафик сгорит вместе с кодом.
+        if traffic > 0 or (days > 0 and balance > 0):
+            promo_type = PromoCodeType.BALANCE_AND_DAYS.value
+        elif days > 0:
             promo_type = PromoCodeType.SUBSCRIPTION_DAYS.value
+        elif balance > 0:
+            promo_type = PromoCodeType.BALANCE.value
+        elif prize.promo_group_id:
+            promo_type = PromoCodeType.PROMO_GROUP.value
         else:
             promo_type = PromoCodeType.BALANCE.value
 
         promocode = PromoCode(
             code=code,
             type=promo_type,
-            balance_bonus_kopeks=prize.promo_balance_bonus_kopeks,
-            subscription_days=prize.promo_subscription_days,
+            balance_bonus_kopeks=balance,
+            subscription_days=days,
+            # promo_traffic_gb объявлен у WheelPrize и настраивается в админке,
+            # но в промокод не переносился — трафиковая часть приза пропадала.
+            traffic_gb=traffic,
+            promo_group_id=prize.promo_group_id,
             max_uses=1,
             valid_until=datetime.now(UTC) + timedelta(days=config.promo_validity_days),
             is_active=True,
@@ -721,7 +744,9 @@ class FortuneWheelService:
             await db.commit()
 
             # 7. Формируем результат
-            message = self._get_prize_message(selected_prize, generated_promocode)
+            message = self._get_prize_message(
+                selected_prize, generated_promocode, validity_days=config.promo_validity_days
+            )
 
             return SpinResult(
                 success=True,
@@ -763,7 +788,7 @@ class FortuneWheelService:
         }
         return messages.get(reason, 'Произошла ошибка')
 
-    def _get_prize_message(self, prize: WheelPrize, promocode: str | None) -> str:
+    def _get_prize_message(self, prize: WheelPrize, promocode: str | None, validity_days: int | None = None) -> str:
         """Сформировать сообщение о выигрыше."""
         prize_type = prize.prize_type
 
@@ -781,7 +806,25 @@ class FortuneWheelService:
             return f'Поздравляем! Вы выиграли {prize.prize_value}GB трафика!'
 
         if prize_type == WheelPrizeType.PROMOCODE.value:
-            return f'Поздравляем! Ваш промокод: {promocode}'
+            # Один голый код ничего не говорит о выигрыше: человек не знает ни
+            # что внутри, ни что код сгорит. Промокод с колеса живёт
+            # promo_validity_days и молча истекал вместе с призом.
+            parts: list[str] = []
+            if prize.promo_subscription_days:
+                days = prize.promo_subscription_days
+                parts.append(f'{days} {self._pluralize_days(days)} подписки')
+            if prize.promo_balance_bonus_kopeks:
+                parts.append(f'{prize.promo_balance_bonus_kopeks / 100:.0f}₽ на баланс')
+            if prize.promo_traffic_gb:
+                parts.append(f'{prize.promo_traffic_gb} ГБ трафика')
+
+            message = 'Поздравляем! Ваш промокод'
+            if parts:
+                message += f' на {", ".join(parts)}'
+            message += f': {promocode}'
+            if validity_days:
+                message += f'\nАктивируйте в течение {validity_days} {self._pluralize_days(validity_days)}.'
+            return message
 
         return 'Поздравляем с выигрышем!'
 

--- a/docs/project_structure_reference.md
+++ b/docs/project_structure_reference.md
@@ -2708,6 +2708,9 @@
 - `migrations/alembic/versions/0115_create_reachability_tables.py` — Python-модуль
   Классы: нет
   Функции: `upgrade`, `downgrade`
+- `migrations/alembic/versions/0116_wheel_prize_promo_group.py` — Python-модуль
+  Классы: нет
+  Функции: `upgrade`, `downgrade`
 
 ## scripts
 
@@ -2837,6 +2840,9 @@
 - `tests/test_wheel_fixes.py` — Python-модуль
   Классы: нет
   Функции: `test_spin_rechecks_daily_limit_under_lock` — Even if check_availability passed, spin() must re-count under the lock and, `test_spin_under_limit_proceeds_to_payment` — Sanity: when the re-check is below the limit, spin() proceeds to payment., `test_stars_wheel_spin_idempotent_on_redelivery` — A successful_payment redelivered with the same charge id must NOT grant a
+- `tests/test_wheel_prize_grants.py` — Python-модуль
+  Классы: нет
+  Функции: `test_get_wheel_prizes_orders_by_sort_order_then_id` — B1: без вторичного ключа порядок при равных sort_order произволен., `test_promocode_prize_carries_traffic_and_promo_group` — B2: гигабайты и промогруппа обязаны доехать до промокода., `test_promocode_prize_with_only_promo_group_gets_promo_group_type` — B2: чисто скидочный приз — код типа promo_group, а не пустой balance., `test_traffic_prize_goes_through_traffic_purchase` — B3: сырой `traffic_limit_gb +=` стирается пересчётом лимита., `test_promocode_message_states_contents_and_validity` — B4: голый код не говорит ни что внутри, ни что он сгорит., `test_promocode_message_without_validity_stays_backward_compatible`
 - `tests/utils/`
 - `tests/webapi/`
 - `tests/webserver/`

--- a/migrations/alembic/versions/0116_wheel_prize_promo_group.py
+++ b/migrations/alembic/versions/0116_wheel_prize_promo_group.py
@@ -1,0 +1,62 @@
+"""wheel prize: promo group for generated promocodes
+
+Revision ID: 0116
+Revises: 0115
+Create Date: 2026-09-06
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = '0116'
+down_revision: Union[str, None] = '0115'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'wheel_prizes' not in inspector.get_table_names():
+        return
+
+    existing = {col['name'] for col in inspector.get_columns('wheel_prizes')}
+    if 'promo_group_id' in existing:
+        return
+
+    op.add_column('wheel_prizes', sa.Column('promo_group_id', sa.Integer(), nullable=True))
+    op.create_index('ix_wheel_prizes_promo_group_id', 'wheel_prizes', ['promo_group_id'])
+    if 'promo_groups' in inspector.get_table_names():
+        op.create_foreign_key(
+            'fk_wheel_prizes_promo_group_id',
+            'wheel_prizes',
+            'promo_groups',
+            ['promo_group_id'],
+            ['id'],
+            ondelete='SET NULL',
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'wheel_prizes' not in inspector.get_table_names():
+        return
+
+    existing = {col['name'] for col in inspector.get_columns('wheel_prizes')}
+    if 'promo_group_id' not in existing:
+        return
+
+    fks = {fk['name'] for fk in inspector.get_foreign_keys('wheel_prizes')}
+    if 'fk_wheel_prizes_promo_group_id' in fks:
+        op.drop_constraint('fk_wheel_prizes_promo_group_id', 'wheel_prizes', type_='foreignkey')
+
+    indexes = {ix['name'] for ix in inspector.get_indexes('wheel_prizes')}
+    if 'ix_wheel_prizes_promo_group_id' in indexes:
+        op.drop_index('ix_wheel_prizes_promo_group_id', table_name='wheel_prizes')
+
+    op.drop_column('wheel_prizes', 'promo_group_id')

--- a/tests/test_wheel_prize_grants.py
+++ b/tests/test_wheel_prize_grants.py
@@ -1,0 +1,132 @@
+"""Regression tests for how the Fortune Wheel actually hands over a prize.
+
+B1 — get_wheel_prizes must order deterministically: _calculate_rotation maps a
+     prize to a sector by its index in that list, so equal sort_order values
+     (the default!) let the DB return an arbitrary order and the pointer stops
+     on a sector that is not the announced prize.
+B2 — a promocode prize must carry every configured bonus into the generated
+     code: promo_traffic_gb was declared on WheelPrize and settable in the admin
+     UI, but never written to the PromoCode, and the traffic leg only applies
+     for type BALANCE_AND_DAYS.
+B3 — a traffic prize must go through add_subscription_traffic (which records a
+     TrafficPurchase row), not a raw `traffic_limit_gb +=`: the limit is
+     recomputed as base_limit + purchased_gb, so a raw bump is wiped by the
+     next renewal or top-up.
+B4 — the promocode win message must say what is inside the code and how long it
+     is valid.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.database.models import PromoCodeType, WheelPrizeType
+from app.services.wheel_service import FortuneWheelService
+
+
+def _prize(**kwargs) -> SimpleNamespace:
+    base = dict(
+        id=1,
+        prize_type=WheelPrizeType.PROMOCODE.value,
+        prize_value=0,
+        prize_value_kopeks=0,
+        display_name='Промокод',
+        promo_balance_bonus_kopeks=0,
+        promo_subscription_days=0,
+        promo_traffic_gb=0,
+        promo_group_id=None,
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def test_get_wheel_prizes_orders_by_sort_order_then_id() -> None:
+    """B1: без вторичного ключа порядок при равных sort_order произволен."""
+    import inspect
+
+    from app.database.crud import wheel as wheel_crud
+
+    source = inspect.getsource(wheel_crud.get_wheel_prizes)
+    assert 'WheelPrize.sort_order, WheelPrize.id' in source
+
+
+@pytest.mark.asyncio
+async def test_promocode_prize_carries_traffic_and_promo_group() -> None:
+    """B2: гигабайты и промогруппа обязаны доехать до промокода."""
+    svc = FortuneWheelService()
+    prize = _prize(promo_subscription_days=7, promo_traffic_gb=50, promo_group_id=3)
+    config = SimpleNamespace(promo_prefix='WHEEL', promo_validity_days=30)
+    db = SimpleNamespace(add=lambda obj: None, flush=AsyncMock())
+
+    created = await svc._generate_prize_promocode(db, SimpleNamespace(id=42), prize, config)
+
+    assert created.traffic_gb == 50
+    assert created.promo_group_id == 3
+    assert created.subscription_days == 7
+    # Трафик применяется только у BALANCE_AND_DAYS (promocode_service).
+    assert created.type == PromoCodeType.BALANCE_AND_DAYS.value
+
+
+@pytest.mark.asyncio
+async def test_promocode_prize_with_only_promo_group_gets_promo_group_type() -> None:
+    """B2: чисто скидочный приз — код типа promo_group, а не пустой balance."""
+    svc = FortuneWheelService()
+    prize = _prize(promo_group_id=5)
+    config = SimpleNamespace(promo_prefix='WHEEL', promo_validity_days=30)
+    db = SimpleNamespace(add=lambda obj: None, flush=AsyncMock())
+
+    created = await svc._generate_prize_promocode(db, SimpleNamespace(id=42), prize, config)
+
+    assert created.type == PromoCodeType.PROMO_GROUP.value
+    assert created.promo_group_id == 5
+
+
+@pytest.mark.asyncio
+async def test_traffic_prize_goes_through_traffic_purchase() -> None:
+    """B3: сырой `traffic_limit_gb +=` стирается пересчётом лимита."""
+    svc = FortuneWheelService()
+    prize = _prize(prize_type=WheelPrizeType.TRAFFIC_GB.value, prize_value=25, prize_value_kopeks=2500)
+    subscription = SimpleNamespace(id=7, traffic_limit_gb=500, updated_at=None)
+    user = SimpleNamespace(id=42)
+    add_traffic = AsyncMock()
+
+    with (
+        patch('app.database.crud.subscription.add_subscription_traffic', add_traffic),
+        patch('app.services.wheel_service.SubscriptionService') as sub_service,
+    ):
+        sub_service.return_value.update_remnawave_user = AsyncMock()
+        await svc._apply_prize(AsyncMock(), user, prize, SimpleNamespace(), subscription)
+
+    add_traffic.assert_awaited_once()
+    args, kwargs = add_traffic.await_args
+    assert args[2] == 25
+    # Спин держит user-lock и коммитит одним куском — вложенный commit его рвёт.
+    assert kwargs['commit'] is False
+    # Лимит руками больше не трогаем: его пересчитает add_subscription_traffic.
+    assert subscription.traffic_limit_gb == 500
+
+
+def test_promocode_message_states_contents_and_validity() -> None:
+    """B4: голый код не говорит ни что внутри, ни что он сгорит."""
+    svc = FortuneWheelService()
+    prize = _prize(promo_subscription_days=30, promo_traffic_gb=100)
+
+    message = svc._get_prize_message(prize, 'WHEELDEADBEEF', validity_days=30)
+
+    assert 'WHEELDEADBEEF' in message
+    assert '30 дней подписки' in message
+    assert '100 ГБ' in message
+    assert '30 дней' in message.split('\n')[-1]
+
+
+def test_promocode_message_without_validity_stays_backward_compatible() -> None:
+    svc = FortuneWheelService()
+    prize = _prize(promo_balance_bonus_kopeks=10000)
+
+    message = svc._get_prize_message(prize, 'WHEELCAFE')
+
+    assert message.startswith('Поздравляем! Ваш промокод на 100₽ на баланс: WHEELCAFE')
+    assert '\n' not in message


### PR DESCRIPTION
## 📝 Описание

Четыре места, где выигрыш в колесе удачи терялся или выглядел не тем, что выпало, и один недостающий тип приза.

**1. Стрелка останавливалась не на объявленном призе.** `get_wheel_prizes` сортирует только по `sort_order`, а `_calculate_rotation` сопоставляет приз сектору по индексу в этой выдаче. `sort_order` по умолчанию `0` у всех призов — при равных ключах порядок в Postgres произволен, и анимация показывала один сектор, а начислялся другой. Со стороны пользователя это выглядит как накрутка. Добавлен вторичный ключ `id`.

**2. Приз `traffic_gb` молча исчезал.** `_apply_prize` делал `subscription.traffic_limit_gb += N` без строки в `traffic_purchases`, а лимит пересчитывается как `base_limit + purchased_gb` (`_apply_base_limit_preserving_active_purchases`) — подарок стирался при первом же продлении или следующей докупке трафика. Переведено на штатный `add_subscription_traffic`, которому добавлен `commit=False`: спин держит user-lock и коммитит всё одним куском (как уже сделано у `add_user_balance`).

**3. `promo_traffic_gb` не доезжал до промокода.** Поле объявлено у `WheelPrize` и настраивается в админке кабинета, но в `_generate_prize_promocode` не переносилось в `PromoCode`. Заодно поправлен выбор типа кода: трафик применяется только у `BALANCE_AND_DAYS` (`PromoCodeService._apply_promocode_effects`), а комбинация «дни + баланс» раньше получала тип `SUBSCRIPTION_DAYS` и молча теряла баланс.

**4. Сообщение о призе-промокоде было голым кодом** — ни состава, ни срока. Промокод с колеса живёт `promo_validity_days`, и пользователь не знал ни что выиграл, ни до когда его активировать.

**Плюс `promo_group_id` у приза колеса.** Назначение промогруппы по промокоду уже полностью реализовано в `PromoCodeService` (включая откат при неудачной активации) — колесу не хватало только способа выдать такой код. Это открывает призы вида «скидка N% на продление»: для оператора это самый дешёвый тип приза, потому что стоит только маржу и провоцирует покупку, а не заменяет её.

## 🎯 Мотивация

Нашлось при разборе колеса на своём проде: RTP был 570% (542 ₽ вошло, 3092 ₽ вышло за 142 спина). Пункты 1–4 — то, что при этом разборе попалось по дороге и воспроизводится независимо от настроек призов.

Отдельно и не в этом PR: расчёт вероятностей в `calculate_prize_probabilities` не попадает в `WheelConfig.rtp_percent` ни при каких настройках. Реальный RTP выходит `k·r / (1 + ставка·r·Σ(1/vᵢ))`, где `k` — число призов с ценностью, а клэмп `max(weight, 0.01)` не даёт выразить вероятность реже ~1/200, из-за чего приз дороже ~20 ставок автоматически выпадает в разы чаще нужного. Готов оформить это отдельным issue с выкладкой и вариантами решения, если интересно — там меняется поведение выплат у всех существующих установок, так что это тема для обсуждения, а не для тихого патча.

## 🔧 Тип изменений

- [x] Bug fix (исправление)
- [x] New feature (новая функция)
- [ ] Breaking change (ломающие изменения)
- [ ] Documentation update (обновление документации)

## ✅ Чеклист

- [x] Код соответствует стандартам проекта (`ruff check` / `ruff format` на затронутых файлах чисто; единственная ошибка в `crud/subscription.py` — предсуществующая, проверено через `git stash`)
- [x] Добавлены тесты — `tests/test_wheel_prize_grants.py`, 6 регрессий в стиле существующего `test_wheel_fixes.py` (без БД)
- [x] Прогнаны затронутые области: `test_wheel_prize_grants` + `test_wheel_fixes` + `test_recurrent_amount_sync` + `test_promocode_service` + `test_combo_promocode` + `test_promocode_promo_group_flow` + оба `test_promocode_traffic_roundtrip` + `test_promocode_crud` + `database/crud/test_subscription` → 62 passed
- [ ] Проверена работа в Docker

## 🗄 Миграция

`0116_wheel_prize_promo_group` — добавляет `wheel_prizes.promo_group_id` (nullable FK на `promo_groups`, `ondelete=SET NULL`). Idempotent, с inspector-guard'ами в обе стороны, по образцу `0110`.

`update_wheel_prize` получил allowlist полей, которым разрешено записывать `NULL`: общий guard `value is not None` иначе не позволял снять с приза промогруппу.
