### PR TITLE
fix(cabinet): respect RESET_TRAFFIC_ON_PAYMENT/TARIFF_SWITCH on tariff purchase

### DIFF
--- a/app/cabinet/routes/subscription_modules/purchase.py
+++ b/app/cabinet/routes/subscription_modules/purchase.py
@@ -1022,6 +1022,12 @@ async def purchase_tariff(
                 subscription.is_trial = False
                 await db.flush()
 
+            # Фиксируем ДО extend_subscription: он мутирует subscription.tariff_id
+            # на новый тариф прямо в переданном объекте, так что сравнение после
+            # вызова всегда было бы "тариф не менялся" — отсюда и баг с
+            # захардкоженным reset_traffic ниже.
+            _purchase_is_tariff_change = bool(subscription and subscription.tariff_id != tariff.id)
+
             if subscription:
                 # Extend/change tariff — сохраняем докупленные устройства при продлении того же тарифа
                 subscription = await extend_subscription(
@@ -1125,14 +1131,27 @@ async def purchase_tariff(
             # past the budget the sync is deferred to remnawave_retry_queue below.
             async with asyncio.timeout(REMNAWAVE_SYNC_TIMEOUT):
                 if not _should_create:
+                    # Раньше здесь стоял голый reset_traffic=True — трафик слетал
+                    # на панели при ЛЮБОЙ покупке/продлении через кабинет, даже с
+                    # выключенным RESET_TRAFFIC_ON_PAYMENT (см. issue про сброс
+                    # трафика при продлении). Обычное продление того же тарифа
+                    # обязано подчиняться настройке, как это уже сделано в
+                    # extend_subscription для БД-счётчика; смена тарифа —
+                    # отдельному переключателю RESET_TRAFFIC_ON_TARIFF_SWITCH.
+                    _reset_traffic = (
+                        settings.RESET_TRAFFIC_ON_TARIFF_SWITCH
+                        if _purchase_is_tariff_change
+                        else settings.RESET_TRAFFIC_ON_PAYMENT
+                    )
                     await service.update_remnawave_user(
                         db,
                         subscription,
-                        reset_traffic=True,
+                        reset_traffic=_reset_traffic,
                         reset_reason='покупка тарифа (cabinet)',
                         sync_squads=True,
                     )
                 else:
+                    # Новый панельный аккаунт — сбрасывать нечего, счётчик и так с нуля.
                     await service.create_remnawave_user(
                         db,
                         subscription,


### PR DESCRIPTION
Fixes #3227.

При покупке/продлении тарифа через веб-кабинет (`POST /cabinet/subscription/purchase-tariff`) синк с панелью RemnaWave звал `update_remnawave_user(..., reset_traffic=True)` — литералом, без единой проверки настроек. Трафик на панели слетал при любой оплате, даже при выключенном `RESET_TRAFFIC_ON_PAYMENT`.

## Что изменилось

- Флаг смены тарифа (`_purchase_is_tariff_change`) теперь фиксируется **до** вызова `extend_subscription`, потому что тот мутирует `subscription.tariff_id` на новый прямо в переданном объекте — сравнение после вызова всегда показывало бы "тариф не менялся".
- Для ветки `update_remnawave_user` (уже существующий панельный аккаунт) сброс трафика теперь решается так же, как это уже сделано для БД-счётчика в `extend_subscription`: `RESET_TRAFFIC_ON_TARIFF_SWITCH` при смене тарифа, иначе `RESET_TRAFFIC_ON_PAYMENT`.
- Ветка `create_remnawave_user` (новый панельный аккаунт) не тронута — сбрасывать там нечего, счётчик и так с нуля.

## Как воспроизводился баг

`RESET_TRAFFIC_ON_PAYMENT=false`, продление того же тарифа через кабинет → приходит уведомление о сбросе трафика, в логах:
```
🔄 Стратегия сброса трафика из тарифа | mapped_strategy=MONTH_ROLLING tariff_mode=MONTH_ROLLING
🔄 Сброшен трафик RemnaWave | reason_text=' (покупка тарифа (cabinet))'
event_name=user.traffic_reset
```

Подробности и живой пример — в issue #3227.